### PR TITLE
Add caching to make pipe faster

### DIFF
--- a/.github/workflows/quality_gate.yml
+++ b/.github/workflows/quality_gate.yml
@@ -1,8 +1,6 @@
 name: Quality gate
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [ main ]
@@ -22,7 +20,11 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install --upgrade --upgrade-strategy eager -r requirements.txt
+    - uses: actions/cache@v2
+      with:
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
     - name: Test migration script
       run: |
         cd utilities

--- a/.github/workflows/quality_gate.yml
+++ b/.github/workflows/quality_gate.yml
@@ -17,14 +17,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.10'
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install --upgrade --upgrade-strategy eager -r requirements.txt
     - uses: actions/cache@v2
       with:
         path: ${{ env.pythonLocation }}
         key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade --upgrade-strategy eager -r requirements.txt
     - name: Test migration script
       run: |
         cd utilities

--- a/README.md
+++ b/README.md
@@ -32,21 +32,22 @@ Tällä hetkellä ainakin nämä ominaisuudet löytyvät:
 
 ## Miten ajetaan
 
-### Vaatimukset: 
+### Vaatimukset:
+
 - Docker
 - Docker Compose
 
 ### Vaiheet:
 
 1. Luo settings.json tiedosto projektin juureen. Esimerkki validista asetustiedostosta: 
-```
+```sh
 {
     "bot_token": "bottisi_token_tähän_sisään.Saat_sen_bot_fatherilta",
     "DJANGO_SECRET_KEY": "tähän_vaan_jotain_salaista_mössöä"
 }
 ```
 2. Luo db.sqlite3 tietokanta
-```shell
+```sh
 cd web
 python3 manage.py migrate
 ```
@@ -55,17 +56,27 @@ python3 manage.py migrate
 ajamalla deploy skripti botin pitäisi lähteä käyntiin. 
 
 #### Linux
+
 ```sh
 ./deploy.sh
+```
 
+##### Paikallinen kehitysympäristö
+
+Jos haluat ajaa bottia suoraan omalla koneella tai esimerkiksi ajaa yksikkötestejä:
+
+```sh
 # For local development:
 # install python3.10
 # install pip:
 curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 alias pip='/home/<user>/.local/bin/pip3.10'
 pip install -r requirements.txt
-```
-#### Windows
-```batch
-./deploy.bat
+
+# Testit
+cd bob
+python -m unittest
+
+cd ../web
+python manage.py test
 ```


### PR DESCRIPTION
Saves the Python packages to a cache, so that every run of the CI pipe will have all the requirements pre-installed if nothing has changed.