### PR TITLE
#76 /help-komento, joka listaa bob-botin featuret:

### DIFF
--- a/bob/constants.py
+++ b/bob/constants.py
@@ -1,0 +1,6 @@
+HANDLER = 'handler'  # method: receives the message that contained the command
+ENABLER = 'enabler'  # method: defines if command is enabled
+REGEX = 'regex'  # regex: custom regex to match the command. If empty, strict match to command name
+HELP_TEXT = 'help_text'  # tuple: [0]: name [1]: description
+COMMAND_PREFIXES = ['.', '/', '!']  # List of supported prefixes
+PREFIXES_MATCHER = '[{}]'.format(''.join(COMMAND_PREFIXES))  # prefixes as regex matcher

--- a/bob/help_command.py
+++ b/bob/help_command.py
@@ -1,0 +1,27 @@
+from constants import HELP_TEXT
+
+
+def help_command(update, commands, longest_name_length):
+    command_heading = form_command_with_tab('Komento', longest_name_length) + 'Selite'
+    command_string_list = form_command_help_list(longest_name_length, commands)
+
+    reply_text = "```\nBob-botti osaa auttaa ainakin seuraavasti:\n\n" \
+                 + command_heading + \
+                 "\n--------------------------------------\n" \
+                 + command_string_list + \
+                 "\nEtumerkillä aloitetut komennot voi aloitta joko huutomerkillä, pisteellä tai etukenolla [!./].\n```"
+    update.message.reply_text(reply_text, parse_mode='Markdown', quote=False)
+
+
+def form_command_with_tab(text, longest_command_length):
+    return text + ' ' * (longest_command_length - len(text)) + ' | '
+
+
+def form_command_help_list(maxlen, commands):
+    output_text = ''
+    for key in commands:
+        if HELP_TEXT in commands[key]:
+            command_text = form_command_with_tab((commands[key][HELP_TEXT])[0], maxlen)
+            description = (commands[key][HELP_TEXT])[1]
+            output_text += command_text + description + '\n'
+    return output_text

--- a/bob/test_main.py
+++ b/bob/test_main.py
@@ -255,7 +255,7 @@ class Test(IsolatedAsyncioTestCase):
         self.assertEqual(update.message.reply_message_text, None)
 
     def test_all_commands_except_help_have_help_text_defined(self):
-        for (name, body) in message_handler.commands.items():
+        for (name, body) in message_handler.commands().items():
             if name != 'help':
                 self.assertTrue(message_handler.HELP_TEXT in body)
                 self.assertTrue(len(body[message_handler.HELP_TEXT]) >= 2)
@@ -267,10 +267,10 @@ class Test(IsolatedAsyncioTestCase):
         message_handler.message_handler(update=update)
         reply = update.message.reply_message_text
 
-        for (name, body) in message_handler.commands.items():
+        for (name, body) in message_handler.commands().items():
             if name != 'help' and message_handler.HELP_TEXT in body:
                 # regex: linebreak followed by optional (.. ), optional command prefix, followed by command name
-                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + message_handler.prefixes_r + '?' + name)
+                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + message_handler.PREFIXES_MATCHER + '?' + name)
 
     def test_low_probability_reply(self):
         update = MockUpdate()


### PR DESCRIPTION
- Refaktoroitu message_handler ja command_handler käyttämän 'commands' sanakirjaa. Motiivi: Helpommin laajennettava tapa lisätä komentoja botille
- Komentoon liittyvät ominaisuudet:
  - handler: metodi joka vastaanottaa komennon sisältävän viestin ja käsittelee sen
  - enabler: metodi joka määrittää onko komento käytettävissä (kytketty päälle kyseisessä chatissa)
  - regex: määritetty regex jolla tarkistetaan komento
  - help_text: selite joka näytetään help-komennolla
- Lisätty 4 testcasea - Help komento
  - että toimii kaikilla etumerkeillä
  - että ei toimi ilman etumerkkiä
  - että kaikille komennoille on määritetty help-tekstien tuple komentojen sanakirjassa
  - että kaikkien komentojen help tulostuu help-komennolla