### PR TITLE
Dockerfile: build jaettu kahteen vaiheeseen.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install --no-install-recommends \
     libjpeg-dev=1:1.5.2-2+deb10u1 \
     libpng-dev=1.6.36-6 -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && python -m venv /venv
 
-RUN python -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 
 COPY requirements.txt requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,31 @@
-FROM python:3.10-slim-buster
-
-WORKDIR /
+FROM python:3.10-slim-buster AS compile-image
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update && apt-get install --no-install-recommends git=1:2.20.1-2+deb10u3 \
-    zlib1g-dev=1:1.2.11.dfsg-1+deb10u1 libjpeg-dev=1:1.5.2-2+deb10u1 libpng-dev=1.6.36-6 -y \
+WORKDIR /
+
+RUN apt-get update && apt-get install --no-install-recommends \
+    python3.7-dev=3.7.3-2+deb10u3 \
+    python3-pip=18.1-5 \
+    python3-setuptools=40.8.0-1 \
+    zlib1g-dev=1:1.2.11.dfsg-1+deb10u1 \
+    libjpeg-dev=1:1.5.2-2+deb10u1 \
+    libpng-dev=1.6.36-6 -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /venv
+ENV PATH="/venv/bin:$PATH"
 
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 
+# Second stage for code and dependencies
+FROM python:3.10-slim-buster AS build-image
+WORKDIR /
+COPY --from=compile-image /venv /venv
 COPY . .
+
+ENV PATH="/venv/bin:$PATH"
 CMD ["/bin/bash", "-c", "/entrypoint.sh"]


### PR DESCRIPTION
- 1. compile-image, jossa tarvittavat dependencyt (ja ehkä extraa), jotta Pillow ja muut kirjastot saadaan käännettyä. Python riippuvuudet buildataan venv kansioon
- 2. build-image, johon kopioidaan compile-imagesta venv kansio, botin koodit ja missä bottia ajetaan
- Ennen tätä uusilla riippubuuksilla imagen koko oli 460mb, näiden jälkeen 267mb
- Toivottavasti myös ratkaisee tilanteen, missä Pillowin kääntäminen ei ole aina onnistunut