### PR TITLE
Kuulutus komennon testit ja bugikorjaukset

### DIFF
--- a/bob/command_huutista.py
+++ b/bob/command_huutista.py
@@ -12,7 +12,7 @@ class HuutistaCommand(ChatCommand):
         )
 
     def handle_update(self, update: Update, context: CallbackContext = None):
-        update.message.reply_text('...joka tuutista! 😂')
+        update.message.reply_text('...joka tuutista! 😂', quote=False)
 
     def is_enabled_in(self, chat):
         return chat.huutista_enabled

--- a/bob/command_or.py
+++ b/bob/command_or.py
@@ -29,7 +29,7 @@ class OrCommand(ChatCommand):
     def or_command(self, update):
         options = self.get_parameters(update.message.text)
         if len(options) > 1:
-            reply = random.choice(options)
+            reply = random.choice(options)  # NOSONAR
             reply = reply.rstrip("?")
             if reply and reply is not None:
                 update.message.reply_text(reply)

--- a/bob/command_rules_of_acquisition.py
+++ b/bob/command_rules_of_acquisition.py
@@ -33,6 +33,6 @@ class RulesOfAquisitionCommand(ChatCommand):
             update.message.reply_text(rules_of_acquisition.dictionary[int(rule_number)], quote=False)
         except (KeyError, ValueError) as e:
             logger.info("Rule not found with key: \"" + str(e) + "\" Sending random rule instead.")
-            random_rule_number = random.choice(list(rules_of_acquisition.dictionary))
+            random_rule_number = random.choice(list(rules_of_acquisition.dictionary))  # NOSONAR
             random_rule = rules_of_acquisition.dictionary[random_rule_number]
             update.message.reply_text(str(random_rule_number) + ". " + random_rule, quote=False)

--- a/bob/command_ruoka.py
+++ b/bob/command_ruoka.py
@@ -32,9 +32,9 @@ class RuokaCommand(ChatCommand):
         recipes_with_parameter_text = [r for r in recipes if parameter in r.replace('-', ' ')]
 
         if len(recipes_with_parameter_text) > 0:
-            reply_text = random.choice(recipes_with_parameter_text)
+            reply_text = random.choice(recipes_with_parameter_text)  # NOSONAR
         else:
-            reply_text = random.choice(recipes)
+            reply_text = random.choice(recipes)  # NOSONAR
 
         update.message.reply_text(reply_text, quote=False)
 

--- a/bob/message_handler.py
+++ b/bob/message_handler.py
@@ -25,8 +25,8 @@ def message_handler(update: Update, context: CallbackContext = None):
     if update.message is not None and update.message.text is not None:
         if update.message.reply_to_message is not None:
             reply_handler(update)
-
-        command_handler(update, context)
+        else:
+            command_handler(update, context)
 
 
 def reply_handler(update):

--- a/bob/message_handler.py
+++ b/bob/message_handler.py
@@ -62,7 +62,7 @@ def find_first_matching_enabled_command(message, enabled_commands) -> Any | None
 
 def low_probability_reply(update, integer=0):  # added int argument for unit testing
     if integer == 0:
-        random_int = random.randint(1, 10000)  # 0,01% probability
+        random_int = random.randint(1, 10000)  # NOSONAR # 0,01% probability
     else:
         random_int = integer
     if random_int == 1:

--- a/bob/test_command_dallemini.py
+++ b/bob/test_command_dallemini.py
@@ -11,7 +11,7 @@ from PIL.JpegImagePlugin import JpegImageFile
 
 import main
 from utils_test import assert_has_reply_to, assert_no_reply_to, assert_reply_contains, \
-    mock_response_with_code, assert_reply_equal, MockResponse
+    mock_response_with_code, assert_reply_equal, MockResponse, assert_get_parameters_returns_expected_value
 
 from command_dallemini import convert_base64_strings_to_images, get_3x3_image_compilation, send_image_response, \
     split_to_chunks, get_image_file_name, DalleMiniCommand
@@ -65,10 +65,7 @@ class Test(IsolatedAsyncioTestCase):
             assert_reply_contains(self, '/dallemini 1337', ['Kuvan luominen epäonnistui. Lisätietoa Bobin lokeissa.'])
 
     def test_get_given_parameter(self):
-        message = '!dallemini test . test/test-test\ntest\ttest .vai test \n '
-        parameter_expected = 'test . test/test-test\ntest\ttest .vai test'
-        parameter_actual = DalleMiniCommand().get_parameters(message)
-        self.assertEqual(parameter_expected, parameter_actual)
+        assert_get_parameters_returns_expected_value(self, '!dallemini', DalleMiniCommand())
 
     def test_send_image_response(self):
         update = MockUpdate()

--- a/bob/test_command_help.py
+++ b/bob/test_command_help.py
@@ -43,10 +43,9 @@ class Test(TestCase):
 
     def test_all_commands_except_help_have_help_text_defined(self):
         for command in message_handler.commands():
-            if command.name != 'help':
-                self.assertIsNotNone(command.help_text_short)
-                self.assertEqual(len(command.help_text_short), 2)  # Tuple has 2 items - name and description
-                self.assertRegex(command.help_text_short[0], r'' + command.name)
+            self.assertIsNotNone(command.help_text_short)
+            self.assertEqual(len(command.help_text_short), 2)  # Tuple has 2 items - name and description
+            self.assertRegex(command.help_text_short[0], r'' + command.name)
 
     def test_all_commands_included_in_help_response(self):
         update = MockUpdate()
@@ -55,9 +54,9 @@ class Test(TestCase):
         reply = update.message.reply_message_text
 
         for command in message_handler.commands():
-            if command.name != 'help' and command.help_text_short is not None:
+            if command.help_text_short is not None:
                 # regex: linebreak followed by optional (.. ), optional command prefix, followed by command name
-                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + PREFIXES_MATCHER + '?' + command.name)
+                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + PREFIXES_MATCHER + '?' + command.help_text_short[0])
 
     def test_each_row_should_be_28_chars_at_most(self):
         update = MockUpdate()

--- a/bob/test_command_help.py
+++ b/bob/test_command_help.py
@@ -43,9 +43,10 @@ class Test(TestCase):
 
     def test_all_commands_except_help_have_help_text_defined(self):
         for command in message_handler.commands():
-            self.assertIsNotNone(command.help_text_short)
-            self.assertEqual(len(command.help_text_short), 2)  # Tuple has 2 items - name and description
-            self.assertRegex(command.help_text_short[0], r'' + command.name)
+            if command.name != 'help':
+                self.assertIsNotNone(command.help_text_short)
+                self.assertEqual(len(command.help_text_short), 2)  # Tuple has 2 items - name and description
+                self.assertRegex(command.help_text_short[0], r'' + command.name)
 
     def test_all_commands_included_in_help_response(self):
         update = MockUpdate()
@@ -54,9 +55,9 @@ class Test(TestCase):
         reply = update.message.reply_message_text
 
         for command in message_handler.commands():
-            if command.help_text_short is not None:
+            if command.name != 'help' and command.help_text_short is not None:
                 # regex: linebreak followed by optional (.. ), optional command prefix, followed by command name
-                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + PREFIXES_MATCHER + '?' + command.help_text_short[0])
+                self.assertRegex(reply, r'(\r\n|\r|\n)(.. )?' + PREFIXES_MATCHER + '?' + command.name)
 
     def test_each_row_should_be_28_chars_at_most(self):
         update = MockUpdate()

--- a/bob/test_command_kuulutus.py
+++ b/bob/test_command_kuulutus.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from unittest import TestCase, mock
+
+import main
+from command_kuulutus import KuulutusCommand
+from utils_test import assert_has_reply_to, assert_no_reply_to, assert_reply_contains, \
+    assert_get_parameters_returns_expected_value
+
+sys.path.append('../web')  # needed for sibling import
+import django
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "web.settings"
+)
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+django.setup()
+from bobapp.models import Chat, TelegramUser, ChatMember, Bob, GitUser
+
+
+class Test(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        os.system("python ../web/manage.py migrate")
+
+    def test_command_should_reply_and_is_case_insensitive(self):
+        assert_has_reply_to(self, '/kuulutus')
+        assert_has_reply_to(self, '.Kuulutus')
+        assert_has_reply_to(self, '!kuulUTUS')
+
+    def test_no_prefix_no_reply(self):
+        assert_no_reply_to(self, 'kuulutus')
+
+    def test_text_before_command_no_reply(self):
+        assert_no_reply_to(self, 'test /kuulutus')
+
+    def test_text_after_command_should_reply(self):
+        assert_has_reply_to(self, '/kuulutus test')
+
+    def test_get_given_parameter(self):
+        assert_get_parameters_returns_expected_value(self, '!kuulutus', KuulutusCommand())
+
+    def test_parameters_are_case_insensitive(self):
+        with mock.patch('database.get_chat', lambda *args, **kwargs: mock.Mock(spec=Chat)):
+            assert_reply_contains(self, '/kuulutus off', ['Kuulutukset ovat nyt pois päältä.'])
+            assert_reply_contains(self, '/kuulutus OFf', ['Kuulutukset ovat nyt pois päältä.'])
+            assert_reply_contains(self, '.kuulutus on', ['Kuulutukset ovat nyt päällä.'])
+            assert_reply_contains(self, '.kuulutus oN', ['Kuulutukset ovat nyt päällä.'])
+
+    def test_no_parameter_new_chat_should_give_help_with_broadcast_on(self):
+        chat = mock.Mock(spec=Chat)
+        chat.broadcast_enabled = True
+
+        with mock.patch('database.get_chat', lambda *args, **kwargs: chat):
+            assert_reply_contains(self, '/kuulutus', ['Käyttö', 'Kytkee kuulutukset', 'ovat päällä'])
+
+    def test_no_parameter_broadcast_is_off_should_give_help_with_broadcast_off(self):
+        chat = mock.Mock(spec=Chat)
+        chat.broadcast_enabled = False
+
+        with mock.patch('database.get_chat', lambda *args, **kwargs: chat):
+            assert_reply_contains(self, '/kuulutus', ['Käyttö', 'Kytkee kuulutukset', 'ovat pois päältä'])
+
+    def test_reply_and_value_change_with_parameter_on(self):
+        chat = mock.Mock(spec=Chat)
+        chat.broadcast_enabled = False
+
+        with mock.patch('database.get_chat', lambda *args, **kwargs: chat):
+            assert_reply_contains(self, '.kuulutus on', ['Kuulutukset ovat nyt päällä.'])
+            self.assertTrue(chat.broadcast_enabled)
+
+    def test_reply_and_value_change_with_parameter_off(self):
+        chat = mock.Mock(spec=Chat)
+        chat.broadcast_enabled = True
+
+        with mock.patch('database.get_chat', lambda *args, **kwargs: chat):
+            assert_reply_contains(self, '.kuulutus off', ['Kuulutukset ovat nyt pois päältä.'])
+            self.assertFalse(chat.broadcast_enabled)

--- a/bob/test_command_ruoka.py
+++ b/bob/test_command_ruoka.py
@@ -3,7 +3,8 @@ from unittest import TestCase, mock
 
 import main
 from command_ruoka import RuokaCommand
-from utils_test import assert_has_reply_to, assert_no_reply_to, assert_reply_contains
+from utils_test import assert_has_reply_to, assert_no_reply_to, assert_reply_contains, \
+    assert_get_parameters_returns_expected_value
 
 
 @mock.patch('random.choice', lambda values: values[0])
@@ -25,10 +26,7 @@ class Test(TestCase):
         assert_has_reply_to(self, '/ruoka test')
 
     def test_get_given_parameter(self):
-        message = '!ruoka test . test/test-test\ntest\ttest .vai test \n '
-        parameter_expected = 'test . test/test-test\ntest\ttest .vai test'
-        parameter_actual = RuokaCommand().get_parameters(message)
-        self.assertEqual(parameter_expected, parameter_actual)
+        assert_get_parameters_returns_expected_value(self, '!ruoka', RuokaCommand())
 
     def test_should_return_a_link(self):
         assert_reply_contains(self, '.ruoka', ['tahnat-ja-marinadit-lisukkeet-gluteeniton'])

--- a/bob/test_command_users.py
+++ b/bob/test_command_users.py
@@ -138,10 +138,10 @@ def get_multi_format_test_array():
 
 
 def create_mock_chat_member(
-        tg_user_name=str(random.randint(1, 10000)),
-        rank=random.randint(1, 50),
-        prestige=random.randint(1, 10),
-        message_count=random.randint(1, 10000)):
+        tg_user_name=str(random.randint(1, 10000)),  # NOSONAR
+        rank=random.randint(1, 50),  # NOSONAR
+        prestige=random.randint(1, 10),  # NOSONAR
+        message_count=random.randint(1, 10000)):  # NOSONAR
     member = mock.Mock(spec=ChatMember)
     member.tg_user = tg_user_name
     member.rank = rank

--- a/bob/test_command_weather.py
+++ b/bob/test_command_weather.py
@@ -5,7 +5,7 @@ import main
 from command_weather import WeatherCommand
 from resources.test.weather_mock_data import helsinki_weather, turku_weather
 from utils_test import assert_has_reply_to, assert_no_reply_to, assert_reply_contains, \
-    MockResponse, mock_response_with_code, MockChatMember
+    MockResponse, mock_response_with_code, MockChatMember, assert_get_parameters_returns_expected_value
 
 
 def mock_response_200_with_weather(*args, **kwargs):
@@ -31,6 +31,9 @@ class Test(TestCase):
     def test_text_after_command_should_reply(self):
         assert_has_reply_to(self, '/sää test')
 
+    def test_get_given_parameter(self):
+        assert_get_parameters_returns_expected_value(self, '!sää', WeatherCommand())
+
     def test_should_contain_weather_data(self):
         assert_reply_contains(self, '/sää helsinki', ['helsinki', 'UTC', 'tuntuu', 'm/s'])
 
@@ -49,8 +52,4 @@ class Test(TestCase):
             with mock.patch('requests.get', lambda *args, **kwargs: mock_response):
                 assert_reply_contains(self, '/sää', ['tää on turku'])
 
-    def test_get_given_parameter(self):
-        message = '!sää test . test/test-test\ntest\ttest .vai test \n '
-        parameter_expected = 'test . test/test-test\ntest\ttest .vai test'
-        parameter_actual = WeatherCommand().get_parameters(message)
-        self.assertEqual(parameter_expected, parameter_actual)
+

--- a/bob/test_main.py
+++ b/bob/test_main.py
@@ -129,29 +129,6 @@ class Test(IsolatedAsyncioTestCase):
         self.assertRegex(update.message.reply_message_text,
                          r"Seuraava.*\n.*Helsinki.*\n.*T-:")
 
-    def test_broadcast_toggle_command(self):
-        update = MockUpdate()
-
-        update.message.text = "/kuulutus On"
-        message_handler.message_handler(update=update)
-        self.assertEqual("Kuulutukset ovat nyt päällä tässä ryhmässä.",
-                         update.message.reply_message_text)
-
-        update.message.text = "/kuulutus hölynpöly"
-        command_kuulutus.broadcast_toggle_command(update=update)
-        self.assertEqual("Tällä hetkellä kuulutukset ovat päällä.",
-                         update.message.reply_message_text)
-
-        update.message.text = "/Kuulutus oFf"
-        command_kuulutus.broadcast_toggle_command(update=update)
-        self.assertEqual("Kuulutukset ovat nyt pois päältä.",
-                         update.message.reply_message_text)
-
-        update.message.text = "/kuulutuS juupeli juu"
-        command_kuulutus.broadcast_toggle_command(update=update)
-        self.assertEqual("Tällä hetkellä kuulutukset ovat pois päältä.",
-                         update.message.reply_message_text)
-
     def test_time_command(self):
         update = MockUpdate()
         update.message.text = "/aika"

--- a/bob/utils_test.py
+++ b/bob/utils_test.py
@@ -11,7 +11,7 @@ from telegram import Message, PhotoSize, Update
 from telegram.utils.helpers import parse_file_input
 
 import message_handler
-from bob.command import ChatCommand
+from command import ChatCommand
 
 sys.path.append('../web')  # needed for sibling import
 import django

--- a/bob/utils_test.py
+++ b/bob/utils_test.py
@@ -7,10 +7,11 @@ import main
 from typing import List, Union, Any
 from unittest import TestCase
 
-from telegram import Message, PhotoSize
+from telegram import Message, PhotoSize, Update
 from telegram.utils.helpers import parse_file_input
 
 import message_handler
+from bob.command import ChatCommand
 
 sys.path.append('../web')  # needed for sibling import
 import django
@@ -23,31 +24,46 @@ django.setup()
 from bobapp.models import Chat
 
 
+# Bob should reply anything to given message
 def assert_has_reply_to(test: TestCase, message_text: string):
     update = MockUpdate().send_text(message_text)
     test.assertIsNotNone(update.message.reply_message_text)
 
 
+# Bob should not reply to given message
 def assert_no_reply_to(test: TestCase, message_text: string):
     update = MockUpdate().send_text(message_text)
     test.assertIsNone(update.message.reply_message_text)
 
 
+# Bobs message should contain all given elements in the list
 def assert_reply_contains(test: TestCase, message_text: string, expected_list: List[type(string)]):
     update = MockUpdate().send_text(message_text)
+    test.assertIsNotNone(update.message.reply_message_text)
     for expected in expected_list:
         test.assertRegex(update.message.reply_message_text, r'' + expected)
 
 
+# Bobs message should contain all given elements in the list
 def assert_reply_not_containing(test: TestCase, message_text: string, expected_list: List[type(string)]):
     update = MockUpdate().send_text(message_text)
+    test.assertIsNotNone(update.message.reply_message_text)
     for expected in expected_list:
         test.assertNotRegex(update.message.reply_message_text, r'' + expected)
 
 
+# Reply should be strictly equal to expected text
 def assert_reply_equal(test: TestCase, message_text: string, expected: string):
     update = MockUpdate().send_text(message_text)
     test.assertEqual(expected, update.message.reply_message_text)
+
+
+# Test Command.get_parameters(message) for given command
+def assert_get_parameters_returns_expected_value(test: TestCase, command_text: str, command: ChatCommand):
+    message = f'{command_text} test . test/test-test\ntest\ttest .vai test \n '
+    parameter_expected = 'test . test/test-test\ntest\ttest .vai test'
+    parameter_actual = command.get_parameters(message)
+    test.assertEqual(parameter_expected, parameter_actual)
 
 
 def always_last_choice(values):
@@ -67,9 +83,11 @@ class MockUser:
 
 
 class MockChat:
-    def __init__(self):
+    def __init__(self, broadcast_enabled=False, *args, **kwargs):
+        del args, kwargs
         self.chat = Chat(1337, 'group')
         self.id = 1337
+        self.broadcast_enabled = broadcast_enabled
 
 
 class MockChatMember:
@@ -107,15 +125,15 @@ class MockBot:
 
 
 class MockMessage:
-    def __init__(self, chat: Chat):
-        self.message: Message = Message(int(random.random()), datetime.datetime.now(), chat)
+    def __init__(self, chat=MockChat()):
+        self.message: Message = Message(int(random.random()), datetime.datetime.now(), chat)  # NOSONAR
         self.text = "/käyttäjät"
         self.reply_message_text = None
         self.reply_to_message = None
         self.reply_image = None
         self.from_user = None
         self.message_id = None
-        self.chat = MockChat()
+        self.chat = chat
         self.bot = MockBot()
 
     def reply_text(self, message, parse_mode=None, quote=None):


### PR DESCRIPTION
Yleinen korjaus: lisätty #NOSONAR kommentit random-paketin kutsuihin, jotta SonarQube ei enää skannaa niitä.

Kuulutus-komennon korjauksia ja testien lisäyksiä:
- kuulutus-komento reagoi nyt kirjainkoosta välittämättä
- kuulutus-komento toimii nyt oikein kolmella alkumerkillä [!./]
- kuulutus-komento toimii nyt myös ryhmissä missä broadcast_enabled == False
- parametrittomaan viestiin vastataan nyt yhdellä help-viestillä, jossa on myös kyseisen chatin nykyinen tila
- kuulutus-komennon testit ovat nyt omassa moduulissaan ja komento on hyvin testattu
- utils_test.py moduuli sisältää nyt helpon assert-metodin ChatCommand.get_parameters() testaukselle ja se otettu käyttöön muiden komentojen testeissä

Korjauksia:
- Bob ei enää reagoi viesteihin jotka ovat vastauksia (esim. päivän kysymysten vastaukset "1337")
- Bob ei enää vastaa replynä 'huutista' viesteihin