### PR TITLE
#183 bug: bob ei osaa käsitellä kuvamediaa sisältäviä viestejä:

### DIFF
--- a/bobweb/bob/activities/daily_question/daily_question_menu_states.py
+++ b/bobweb/bob/activities/daily_question/daily_question_menu_states.py
@@ -181,19 +181,19 @@ class DQStatsMenuState(ActivityState):
 
         footer = 'V1=Voitot, V2=Vastaukset'
 
-        reply_text = '```\n' \
-                     + 'Päivän kysyjät \U0001F9D0\n\n' \
+        reply_text = 'Päivän kysyjät \U0001F9D0\n\n' \
                      + f'Kausi: {current_season.season_name}\n' \
-                       f'Kysymyksiä esitetty: {current_season.dailyquestion_set.count()}\n\n' \
+                     + f'Kysymyksiä esitetty: {current_season.dailyquestion_set.count()}\n\n' \
+                     + f'```\n' \
                      + f'{formatted_members_array_str}\n' \
-                     + f'{footer}' \
-                     + '```'  # '\U0001F913' => nerd emoji, '```' =>  markdown code block start/end
-
+                     + f'```\n' \
+                     + f'{footer}'
+        reply_with_heading = dq_main_menu_text_body(reply_text)
         buttons = [[
             back_button,
             InlineKeyboardButton(text='Lataa xlsx-muodossa 💾', callback_data='/get_xlsx')
         ]]
-        self.activity.reply_or_update_host_message(reply_text, InlineKeyboardMarkup(buttons))
+        self.activity.reply_or_update_host_message(reply_with_heading, InlineKeyboardMarkup(buttons))
 
     def handle_response(self, response_data: str, context: CallbackContext = None):
         match response_data:
@@ -256,7 +256,8 @@ def create_member_array(users: List[TelegramUser], all_a: List[DailyQuestionAnsw
         q_answered = single_a_per_q(users_answers)
         users_a_count = len(q_answered)
         users_w_count = len([a for a in users_answers if a.is_winning_answer])
-        row = [str(user.username), users_w_count, users_a_count]
+        user_name = user.username if has(user.username) else f'{user.first_name} {user.last_name}'
+        row = [str(user_name), users_w_count, users_a_count]
         users_array.append(row)
 
     # Sort users in order of wins [desc], then answers [asc]

--- a/bobweb/bob/activities/daily_question/message_utils.py
+++ b/bobweb/bob/activities/daily_question/message_utils.py
@@ -1,6 +1,6 @@
 # Messages that are used by multiple modules. Here to prevent circular module initialization problem
 def dq_saved_msg(winner_set) -> str:
-    return f'Kysymys {and_winner_saved_msg if winner_set else ""} tallennettu'
+    return f'Kysymys {and_winner_saved_msg if winner_set else ""}tallennettu'
 
 
 def dq_created_from_msg_edit(winner_set) -> str:

--- a/bobweb/bob/database.py
+++ b/bobweb/bob/database.py
@@ -164,7 +164,7 @@ def find_all_dq_in_season(chat_id: int, target_datetime: datetime) -> QuerySet:
         season__chat=chat_id,
         season__start_datetime__lte=target_datetime) \
         .filter(Q(season__end_datetime=None) | Q(season__end_datetime__gte=target_datetime)) \
-        .order_by('-id')
+        .order_by('-date_of_question')   # order by date of question descending
 
 
 def is_first_dq_in_season(update: Update) -> bool:

--- a/bobweb/bob/message_handler.py
+++ b/bobweb/bob/message_handler.py
@@ -18,6 +18,11 @@ def handle_update(update: Update, context: CallbackContext = None):
     database.update_chat_in_db(update)
     database.update_user_in_db(update)
 
+    if has(update.effective_message) and has(update.effective_message.caption):
+        # Update contains image media and message text is in caption attribute.
+        # Set caption to text attribute, so that the message is handled same way as messages without image media.
+        update.effective_message.text = update.effective_message.caption
+
     if has(update.effective_message) and has(update.effective_message.text):
         process_update(update, context)
 

--- a/bobweb/bob/tests_utils.py
+++ b/bobweb/bob/tests_utils.py
@@ -174,6 +174,7 @@ class MockMessage:
         self.chat = chat
         self.chat_id = chat.id
         self.bot = MockBot()
+        self.caption = None
 
     def reply_text(self, message, reply_markup: ReplyMarkup = None, parse_mode=None, quote=None):
         del parse_mode, quote
@@ -197,6 +198,7 @@ class MockMessage:
         photo = parse_file_input(image, PhotoSize, filename=caption)
         self.reply_image = photo
         self.reply_message_text = caption
+        self.caption = caption
         print(caption)
         return self
 


### PR DESCRIPTION
- Bob nappaa nyt kuvamediaa sisältävän viestin caption-attribuutin arvon ja sijoittaa sen text-attribuuttiin heti updaten käsittelyketjun alussa. Nyt kuvan sisältävät viestit käsitellään kuten kuvattomatkin sekä päivän kysymyksen, että muiden toimintojen osalta