### PR TITLE
#189 päivän kysymys give user way to handle no-winner-set exception:

### DIFF
--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -106,11 +106,11 @@ def set_author_as_prev_dq_winner(update: Update, prev_dq: DailyQuestion) -> True
         return False
 
     users_answer_to_prev_dq = answers_to_dq.filter(answer_author=update.effective_user.id).first()
-    if has_one(users_answer_to_prev_dq):  # quite probable
+    if has_one(users_answer_to_prev_dq):
         users_answer_to_prev_dq.is_winning_answer = True
         users_answer_to_prev_dq.save()
         return True
-    else:
+    else:  # quite probable
         update.effective_message.reply_text(no_answer_found_for_last_dq_msg, quote=True)
         return False
 
@@ -215,10 +215,7 @@ def handle_mark_message_as_answer_command(update):
     # THEN  - set saved answer to be the winning one and set response to reflect that
 
     no_winning_answer = database.find_answers_for_dq(dq_on_target_date.id).filter(is_winning_answer=True).count() == 0
-    try:
-        next_dq: DailyQuestion | None = dq_on_target_date.get_next_by_date_of_question()
-    except Exception:
-        next_dq = None  # No next question
+    next_dq = database.find_next_dq_or_none(dq_on_target_date)
 
     if no_winning_answer and has(next_dq) and next_dq.question_author.id == answer_author.id:
         answer.is_winning_answer = True

--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -10,7 +10,7 @@ from bobweb.bob.activities.daily_question.date_confirmation_states import Confir
 from bobweb.bob.activities.daily_question.message_utils import dq_saved_msg, dq_created_from_msg_edit
 from bobweb.bob.activities.daily_question.start_season_states import SetSeasonStartDateState
 from bobweb.bob.activities.daily_question.daily_question_menu_states import DQMainMenuState
-from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer
+from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer, TelegramUser
 from bobweb.bob.command import ChatCommand
 from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
 from bobweb.bob import database
@@ -97,22 +97,28 @@ def set_author_as_prev_dq_winner(update: Update, prev_dq: DailyQuestion) -> True
 
     answers_to_dq = database.find_answers_for_dq(prev_dq.id)
 
-    if has_no(answers_to_dq):
+    if has_no(answers_to_dq):  # possible, but unlikely
         respond_with_winner_set_fail_msg(update, 'Edelliseen kysymykseen ei ole lainkaan vastauksia.')
         return False
 
-    if has_winner(answers_to_dq):
+    if has_winner(answers_to_dq):  # would only happen in case of a bug
         respond_with_winner_set_fail_msg(update, 'Edellisen kysymyksen voittaja on jo merkattu.')
         return False
 
     users_answer_to_prev_dq = answers_to_dq.filter(answer_author=update.effective_user.id).first()
-    if has_one(users_answer_to_prev_dq):
+    if has_one(users_answer_to_prev_dq):  # quite probable
         users_answer_to_prev_dq.is_winning_answer = True
         users_answer_to_prev_dq.save()
         return True
     else:
-        respond_with_winner_set_fail_msg(update, 'Kysyjällä ei ole vastausta edelliseen kysymykseen.')
+        update.effective_message.reply_text(no_answer_found_for_last_dq_msg, quote=True)
         return False
+
+
+no_answer_found_for_last_dq_msg = 'Sinulta ei löytynyt lainkaan tallennettua vastausta edelliseen päivän kysymykseen, ' \
+                                  'eikä voittoasi voitu merkitä tämän takia. Merkkaa edellinen vastauksesi ' \
+                                  'vastaamalla (reply) edelliseen kysymykseen esittämääsi vastausviestiin viestillä, ' \
+                                  'joka sisältää \'\\vastaus\'.'
 
 
 def has_winner(answers: QuerySet) -> bool:
@@ -196,10 +202,32 @@ def handle_mark_message_as_answer_command(update):
     # Check that message_with_answer has not yet been saved as an answer
     answer_from_database = database.find_answer_by_message_id(message_with_answer.message_id)
     if has(answer_from_database):
-        update.effective_message.reply_text('Kohdeviesti on jo tallennettu aiemmin.')
+        update.effective_message.reply_text('Kohdeviesti on jo tallennettu aiemmin vastaukseksi.')
         return  # Target message has already been saved as an answer to a question
 
     dq_on_target_date = DailyQuestion.objects.filter(created_at__lt=message_with_answer.date).first()
     answer_author = database.get_telegram_user(message_with_answer.from_user.id)
-    database.save_dq_answer(message_with_answer, dq_on_target_date, answer_author)
-    update.effective_message.reply_text('Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!')
+    answer = database.save_dq_answer(message_with_answer, dq_on_target_date, answer_author)
+    reply_msg = target_msg_saved_as_answer_msg
+
+    # IF    - dq on target date has no winning answer set yet,
+    #   AND - message_with_answer author has sent the next daily question
+    # THEN  - set saved answer to be the winning one and set response to reflect that
+
+    no_winning_answer = database.find_answers_for_dq(dq_on_target_date.id).filter(is_winning_answer=True).count() == 0
+    try:
+        next_dq: DailyQuestion | None = dq_on_target_date.get_next_by_date_of_question()
+    except Exception:
+        next_dq = None  # No next question
+
+    if no_winning_answer and has(next_dq) and next_dq.question_author.id == answer_author.id:
+        answer.is_winning_answer = True
+        answer.save()
+        reply_msg = target_msg_saved_as_winning_answer_msg
+
+    update.effective_message.reply_text(reply_msg)
+
+
+target_msg_saved_as_answer_msg = 'Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!'
+target_msg_saved_as_winning_answer_msg = 'Kohdeviesti tallennettu vastauksena ja merkattu onnistuneesti voittaneeksi' \
+                                         'vastaukseksi päivän kysymykseen'

--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -97,10 +97,6 @@ def set_author_as_prev_dq_winner(update: Update, prev_dq: DailyQuestion) -> True
 
     answers_to_dq = database.find_answers_for_dq(prev_dq.id)
 
-    if has_no(answers_to_dq):  # possible, but unlikely
-        respond_with_winner_set_fail_msg(update, 'Edelliseen kysymykseen ei ole lainkaan vastauksia.')
-        return False
-
     if has_winner(answers_to_dq):  # would only happen in case of a bug
         respond_with_winner_set_fail_msg(update, 'Edellisen kysymyksen voittaja on jo merkattu.')
         return False
@@ -118,7 +114,7 @@ def set_author_as_prev_dq_winner(update: Update, prev_dq: DailyQuestion) -> True
 no_answer_found_for_last_dq_msg = 'Sinulta ei löytynyt lainkaan tallennettua vastausta edelliseen päivän kysymykseen, ' \
                                   'eikä voittoasi voitu merkitä tämän takia. Merkkaa edellinen vastauksesi ' \
                                   'vastaamalla (reply) edelliseen kysymykseen esittämääsi vastausviestiin viestillä, ' \
-                                  'joka sisältää \'\\vastaus\'.'
+                                  'joka sisältää \'/vastaus\'.'
 
 
 def has_winner(answers: QuerySet) -> bool:
@@ -205,7 +201,8 @@ def handle_mark_message_as_answer_command(update):
         update.effective_message.reply_text('Kohdeviesti on jo tallennettu aiemmin vastaukseksi.')
         return  # Target message has already been saved as an answer to a question
 
-    dq_on_target_date = DailyQuestion.objects.filter(created_at__lt=message_with_answer.date).first()
+    dq_on_target_date = DailyQuestion.objects.filter(created_at__lt=message_with_answer.date,
+                                                     season__chat__id=message_with_answer.chat.id).first()
     answer_author = database.get_telegram_user(message_with_answer.from_user.id)
     answer = database.save_dq_answer(message_with_answer, dq_on_target_date, answer_author)
     reply_msg = target_msg_saved_as_answer_msg
@@ -226,5 +223,5 @@ def handle_mark_message_as_answer_command(update):
 
 
 target_msg_saved_as_answer_msg = 'Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!'
-target_msg_saved_as_winning_answer_msg = 'Kohdeviesti tallennettu vastauksena ja merkattu onnistuneesti voittaneeksi' \
-                                         'vastaukseksi päivän kysymykseen'
+target_msg_saved_as_winning_answer_msg = 'Kohdeviesti tallennettu onnistuneesti voittaneena vastauksena sitä ' \
+                                         'edeltäneeseen päivän kysymykseen'

--- a/bobweb/bob/database.py
+++ b/bobweb/bob/database.py
@@ -220,6 +220,13 @@ def find_answer_by_message_id(message_id: int) -> QuerySet:
     return DailyQuestionAnswer.objects.filter(message_id=message_id)
 
 
+def find_next_dq_or_none(dq: DailyQuestion) -> DailyQuestion | None:
+    try:
+        return dq.get_next_by_date_of_question()
+    except DailyQuestion.DoesNotExist:
+        return None  # No next question
+
+
 # ########################## Daily Question season ########################################
 def save_dq_season(chat_id: int, start_datetime: datetime, season_name=1) -> DailyQuestionSeason:
     chat = get_chat(chat_id)

--- a/bobweb/bob/test/daily_question/test_dq_questions_and_answers.py
+++ b/bobweb/bob/test/daily_question/test_dq_questions_and_answers.py
@@ -192,18 +192,6 @@ class DailyQuestionTestSuiteV2(TestCase):
         chat, user = init_chat_user()
         assert_winner_not_set_no_answer_to_last_dq_from_author(self, chat, user)
 
-    def test_gives_error_when_saving_winner_if_no_answers_to_prev_dq(self):
-        chat, user = init_chat_user()
-        populate_season_v2(chat)
-        user.send_message('#päivänkysymys dq without answers')
-
-        user2 = MockUser(chat=chat)
-        user2.send_message('#päivänkysymys should give error as no answers to last dq')
-
-        expected_reply = 'Syy: Edelliseen kysymykseen ei ole lainkaan vastauksia.'
-        self.assertIn(expected_reply, chat.bot.messages[-2].text)  # Error should be second last message from bot
-        assert_there_are_no_winning_answers(self)
-
     # This should not be able to happend at all, but let's test for it anyway
     def test_gives_error_when_saving_winner_if_winner_already_set(self):
         chat, user = init_chat_user()
@@ -218,6 +206,7 @@ class DailyQuestionTestSuiteV2(TestCase):
 
         expected_reply = 'Syy: Edellisen kysymyksen voittaja on jo merkattu.'
         self.assertIn(expected_reply, chat.bot.messages[-2].text)  # Error should be second last message from bot
+
 
 def assert_winner_not_set_no_answer_to_last_dq_from_author(case: TestCase, chat: MockChat, user: MockUser):
     populate_season_with_dq_and_answer_v2(chat)

--- a/bobweb/bob/test/daily_question/test_mark_answer_command.py
+++ b/bobweb/bob/test/daily_question/test_mark_answer_command.py
@@ -6,11 +6,17 @@ from freezegun import freeze_time
 from bobweb.bob import main  # needed to not cause circular import
 from django.test import TestCase
 
-from bobweb.bob.command_daily_question import MarkAnswerCommand
+from bobweb.bob.command_daily_question import target_msg_saved_as_winning_answer_msg, target_msg_saved_as_answer_msg
+from bobweb.bob.test.daily_question.test_dq_questions_and_answers import \
+    assert_winner_not_set_no_answer_to_last_dq_from_author
 from bobweb.bob.test.daily_question.utils import populate_season_with_dq_and_answer_v2
 from bobweb.bob.tests_mocks_v2 import init_chat_user, MockUser
 from bobweb.bob.tests_utils import assert_has_reply_to, assert_get_parameters_returns_expected_value, assert_no_reply_to
 from bobweb.web.bobapp.models import DailyQuestionAnswer
+
+
+answer_command_msg = '/vastaus'
+
 
 @freeze_time('2023-01-02', tick=True)  # Set default time to first monday of 2023 as business logic depends on the date
 class DailyQuestionTestSuiteV2(TestCase):
@@ -21,7 +27,7 @@ class DailyQuestionTestSuiteV2(TestCase):
         os.system("python ../web/manage.py migrate")
 
     def test_should_reply_to_question_commands_case_insenstivite_all_prefixes(self):
-        assert_has_reply_to(self, "/vastaus")
+        assert_has_reply_to(self, answer_command_msg)
         assert_has_reply_to(self, "!VAStaus")
         assert_has_reply_to(self, ".vastaus")
         assert_no_reply_to(self, ".vastaus 2000-01-01")
@@ -36,8 +42,8 @@ class DailyQuestionTestSuiteV2(TestCase):
         answer_to_be_marked = user.send_message('answer to dq')
         self.assertEqual(1, DailyQuestionAnswer.objects.count())
 
-        user.send_message('/vastaus', reply_to_message=answer_to_be_marked)
-        self.assertIn('Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!', chat.last_bot_txt())
+        user.send_message(answer_command_msg, reply_to_message=answer_to_be_marked)
+        self.assertIn(target_msg_saved_as_answer_msg, chat.last_bot_txt())
         self.assertEqual(2, DailyQuestionAnswer.objects.count())
 
     def test_gives_notification_if_target_message_already_saved_as_answer(self):
@@ -45,8 +51,8 @@ class DailyQuestionTestSuiteV2(TestCase):
         populate_season_with_dq_and_answer_v2(chat)
 
         last_answer_msg = chat.last_user_msg()
-        user.send_message('/vastaus', reply_to_message=last_answer_msg)
-        self.assertIn('Kohdeviesti on jo tallennettu aiemmin.', chat.last_bot_txt())
+        user.send_message(answer_command_msg, reply_to_message=last_answer_msg)
+        self.assertIn('Kohdeviesti on jo tallennettu aiemmin vastaukseksi.', chat.last_bot_txt())
 
     def test_message_is_saved_as_answer_to_last_dq_from_its_date_when_marked(self):
         chat, user1 = init_chat_user()
@@ -55,14 +61,24 @@ class DailyQuestionTestSuiteV2(TestCase):
         answer_to_be_marked = user1.send_message('answer to dq')
         self.assertEqual(1, DailyQuestionAnswer.objects.count())
 
-        user2 = chat.users[-1]  # user with prepopulated message
+        user2 = chat.users[0]  # user with prepopulated message
         user2.send_message('#päivänkysymys new question')
 
         # Now we want to mark answer that is intended to the non-last dq
-        user1.send_message('/vastaus', reply_to_message=answer_to_be_marked)
-        self.assertIn('Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!', chat.last_bot_txt())
+        user1.send_message(answer_command_msg, reply_to_message=answer_to_be_marked)
+        self.assertIn(target_msg_saved_as_answer_msg, chat.last_bot_txt())
         self.assertEqual(2, DailyQuestionAnswer.objects.count())
 
         # In addition, check that the marked answers target dq is the right one
         target_dq = DailyQuestionAnswer.objects.filter(message_id=answer_to_be_marked.message_id).first().question
         self.assertEqual('#päivänkysymys dq1', target_dq.content)
+
+    def test_when_answer_is_marked_if_user_is_author_of_next_question_the_question_is_set_as_winning_one(self):
+        chat, user = init_chat_user()
+        assert_winner_not_set_no_answer_to_last_dq_from_author(self, chat, user)
+        # So now user has sent new dq and been informed, that their answer was not saved as winning one (no answer)
+        message_to_mark = user.messages[0]
+        user.send_message(answer_command_msg, reply_to_message=message_to_mark)
+        self.assertEqual(target_msg_saved_as_winning_answer_msg, chat.last_bot_txt())
+        users_answer = DailyQuestionAnswer.objects.filter(answer_author__id=user.id).first()
+        self.assertTrue(users_answer.is_winning_answer)

--- a/bobweb/bob/test/daily_question/test_mark_answer_command.py
+++ b/bobweb/bob/test/daily_question/test_mark_answer_command.py
@@ -11,7 +11,7 @@ from bobweb.bob.test.daily_question.test_dq_questions_and_answers import \
     assert_winner_not_set_no_answer_to_last_dq_from_author
 from bobweb.bob.test.daily_question.utils import populate_season_with_dq_and_answer_v2
 from bobweb.bob.tests_mocks_v2 import init_chat_user, MockUser
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_get_parameters_returns_expected_value, assert_no_reply_to
+from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
 from bobweb.web.bobapp.models import DailyQuestionAnswer
 
 


### PR DESCRIPTION
- Now if user gives a daily question but they have no answer to the last dq, bot gives more informative message. User is directed to mark their answer message as answer with '/vastaus' command.
- Now when message is marked with '/vastaus' command, a check is made. If author of the message that was replied with the '/vastaus' command is the same telegram user that gave the next daily question after that answer,, the answer is marked as winning one straight away and user is informed of that.
- Extracted common test chat sequence to static function and created test case for marking users message as answer after bot has informed that setting winner has failed