### PR TITLE
Minor improvements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ class UusiKomento(ChatCommand):
     def __init__(self):
         super().__init__(
             name='uusiKomento',
-            regex=r'' + PREFIXES_MATCHER + 'uusiKomento',
+            regex=regex_simple_command('uusiKomento'),
             help_text_short=('uusiKomento', 'tähän pari sanaa enemmän')
         )
 

--- a/bobweb/bob/activities/daily_question/daily_question_menu_states.py
+++ b/bobweb/bob/activities/daily_question/daily_question_menu_states.py
@@ -5,7 +5,7 @@ import io
 from telegram.ext import CallbackContext
 
 from django.db.models import QuerySet
-from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+from telegram import InlineKeyboardMarkup, InlineKeyboardButton, ParseMode
 import xlsxwriter
 
 from bobweb.bob import database
@@ -183,16 +183,17 @@ class DQStatsMenuState(ActivityState):
 
         footer = 'V1=Voitot, V2=Vastaukset'
 
-        reply_text = 'Päivän kysyjät \U0001F9D0\n\n' \
+        msg_body = 'Päivän kysyjät \U0001F9D0\n\n' \
                      + f'Kausi: {current_season.season_name}\n' \
                      + f'Kysymyksiä esitetty: {current_season.dailyquestion_set.count()}\n\n' \
                      + f'```\n' \
-                     + f'{formatted_members_array_str}\n' \
+                     + f'{formatted_members_array_str}' \
                      + f'```\n' \
                      + f'{footer}'
-        reply_with_heading = dq_main_menu_text_body(reply_text)
+        msg = dq_main_menu_text_body(msg_body)
+
         markup = InlineKeyboardMarkup([[back_button, get_xlsx_btn]])
-        self.activity.reply_or_update_host_message(reply_with_heading, markup)
+        self.activity.reply_or_update_host_message(msg, markup, ParseMode.MARKDOWN)
 
     def handle_response(self, response_data: str, context: CallbackContext = None):
         match response_data:

--- a/bobweb/bob/activities/daily_question/date_confirmation_states.py
+++ b/bobweb/bob/activities/daily_question/date_confirmation_states.py
@@ -60,7 +60,8 @@ def day_buttons():
     prev_day = prev_weekday(fitz_today)
     prev_day_name = 'Eilen' if fitz_today - timedelta(days=1) == prev_day else 'Edellinen arkipäivä'
     prev_day_text = f'{prev_day_name} {fi_short_day_name(prev_day)} {fitzstr_from(prev_day)}'
-    return [[
-        InlineKeyboardButton(text=prev_day_text, callback_data=str(prev_day)),
-        InlineKeyboardButton(text=today_text, callback_data=str(fitz_today)),
-    ]]
+    # Buttons are on top of each other (on their own rows)
+    return [
+        [InlineKeyboardButton(text=prev_day_text, callback_data=str(prev_day))],
+        [InlineKeyboardButton(text=today_text, callback_data=str(fitz_today))]
+    ]

--- a/bobweb/bob/command.py
+++ b/bobweb/bob/command.py
@@ -1,7 +1,7 @@
 import os
 import re
 import string
-import sys
+from typing import TypeVar
 
 from telegram import Update
 from telegram.ext import CallbackContext
@@ -19,6 +19,9 @@ from telegram.ext import CallbackContext
 #   - [1]: short description of the command
 #   - Help text is used by HelpCommand to list available commands in chat
 import django
+
+from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
     "bobweb.web.web.settings"
@@ -57,3 +60,39 @@ class ChatCommand:
     # Everything after command regex match with whitespaces stripped
     def get_parameters(self, text: string) -> string:
         return ''.join(re.split(self.regex, text)).strip()
+
+
+# Static ChatCommand class type for any type checking
+chat_command_class_type = TypeVar('chat_command_class_type', bound=ChatCommand)
+
+
+def regex_simple_command(command_str: str):
+    """
+    Returns a str type regex matcher for command. triggers if message
+    _only contains_ given command with prefix (case-insensitive)
+
+    regex:
+    - (?i) = case insensitive flag
+    - ^ = from the start of the string
+    - [./!] = any character defined in brackets
+    - $ = end of the string
+
+    :param command_str: command without prefix
+    :return: str regex matcher that detects if message contains given command
+    """
+    return rf'(?i)^{PREFIXES_MATCHER}{command_str}$'
+
+
+def regex_command_with_parameters(command_str: str):
+    """
+    Returns a str type regex matcher for command. triggers if message
+    _starts with_ given command with prefix (case-insensitive)
+
+    regex:
+    - check 'regex_match_case_insensitive_with_prefix_only_command'
+    - ($|\s) = either end of string or white space without end of string
+
+    :param command_str: command without prefix
+    :return: str regex matcher that detects if message contains given command
+    """
+    return rf'(?i)^{PREFIXES_MATCHER}{command_str}($|\s)'

--- a/bobweb/bob/command_aika.py
+++ b/bobweb/bob/command_aika.py
@@ -1,17 +1,16 @@
 from telegram.ext import CallbackContext
 
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER, fitz
+from bobweb.bob.command import ChatCommand, regex_simple_command
+from bobweb.bob.resources.bob_constants import fitz
 from telegram import Update
 import datetime
-import pytz
 
 
 class AikaCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='aika',
-            regex=r'' + PREFIXES_MATCHER + 'aika',
+            regex=regex_simple_command('aika'),
             help_text_short=('!aika', 'Kertoo ajan')
         )
 

--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -10,9 +10,8 @@ from bobweb.bob.activities.daily_question.date_confirmation_states import Confir
 from bobweb.bob.activities.daily_question.message_utils import dq_saved_msg, dq_created_from_msg_edit
 from bobweb.bob.activities.daily_question.start_season_states import SetSeasonStartDateState
 from bobweb.bob.activities.daily_question.daily_question_menu_states import DQMainMenuState
-from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer, TelegramUser
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer
+from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob import database
 from bobweb.bob.utils_common import has_one, has_no, has, auto_remove_msg_after_delay, weekday_count_between
 
@@ -23,7 +22,7 @@ class DailyQuestionHandler(ChatCommand):
     def __init__(self):
         super().__init__(
             name='#päivänkysymys',
-            regex=r'(?i)#päivänkysymys',
+            regex=r'(?i)#päivänkysymys',  # case-insensitive and detected from anywhere in the message
             help_text_short=('#päivänkysymys', 'kyssäri')
         )
 
@@ -153,7 +152,7 @@ class DailyQuestionCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='kysymys',
-            regex=f'(?i)^{PREFIXES_MATCHER}kysymys$',
+            regex=regex_simple_command('kysymys'),
             help_text_short=('/kysymys', 'kyssärikomento')
         )
 
@@ -177,7 +176,7 @@ class MarkAnswerCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='vastaus',
-            regex=f'(?i)^{PREFIXES_MATCHER}vastaus$',
+            regex=regex_simple_command('vastaus'),
             help_text_short=('/vastaus', 'merkkaa vastauksen')
         )
 

--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -142,7 +142,7 @@ def check_and_handle_reply_to_daily_question(update: Update, context: CallbackCo
 
 def respond_with_winner_set_fail_msg(update: Update, reason: string):
     message_text = f'Odotettu virhe edellisen kysymyksen voittajan tallentamisessa.\nSyy: {reason}'
-    update.effective_message.reply_text(message_text, quote=False, parse_mode='Markdown')
+    update.effective_message.reply_text(message_text, quote=False)
 
 
 # ####################### DAILY QUESTION COMMANDS ######################################

--- a/bobweb/bob/command_dallemini.py
+++ b/bobweb/bob/command_dallemini.py
@@ -1,19 +1,20 @@
 import logging
-import re
 import string
 from typing import List
 
+import django
 import requests
 import ast
 import datetime
-import pytz
-import io, base64
+import io
+import base64
 from PIL import Image
+from django.utils import html
 
 from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER, fitz, FILE_NAME_DATE_FORMAT
 from django.utils.text import slugify
 from requests import Response
-from telegram import Update
+from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
 from bobweb.bob.command import ChatCommand
@@ -58,7 +59,7 @@ def handle_image_generation_and_reply(update: Update, prompt: string) -> None:
         send_image_response(update, prompt, image_compilation)
 
     except ImageGenerationException as e:  # If exception was raised, reply its response_text
-        update.effective_message.reply_text(e.response_text, quote=True, parse_mode='Markdown')
+        update.effective_message.reply_text(e.response_text, quote=True)
 
 
 def generate_and_format_result_image(prompt: string) -> Image:
@@ -74,8 +75,8 @@ def generate_and_format_result_image(prompt: string) -> Image:
 
 def send_image_response(update: Update, prompt: string, image_compilation: Image) -> None:
     image_bytes = image_to_byte_array(image_compilation)
-    caption = '"_' + prompt + '_"'  # between quotes in italic
-    update.effective_message.reply_photo(image_bytes, caption, quote=True, parse_mode='Markdown')
+    caption = '"<i>' + django.utils.html.escape(prompt) + '</i>"'  # between quotes in italic
+    update.effective_message.reply_photo(image_bytes, caption, quote=True, parse_mode=ParseMode.HTML)
 
 
 def post_prompt_request_to_api(prompt: string) -> Response:

--- a/bobweb/bob/command_dallemini.py
+++ b/bobweb/bob/command_dallemini.py
@@ -11,13 +11,13 @@ import base64
 from PIL import Image
 from django.utils import html
 
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER, fitz, FILE_NAME_DATE_FORMAT
+from bobweb.bob.resources.bob_constants import fitz, FILE_NAME_DATE_FORMAT
 from django.utils.text import slugify
 from requests import Response
 from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
-from bobweb.bob.command import ChatCommand
+from bobweb.bob.command import ChatCommand, regex_command_with_parameters
 from bobweb.bob.utils_common import split_to_chunks
 
 logger = logging.getLogger(__name__)
@@ -29,7 +29,7 @@ class DalleMiniCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='dallemini',
-            regex=r'^' + PREFIXES_MATCHER + r'dallemini($|\s)',
+            regex=regex_command_with_parameters('dallemini'),
             help_text_short=('!dallemini', '[prompt] -> kuva')
         )
 

--- a/bobweb/bob/command_epic_games.py
+++ b/bobweb/bob/command_epic_games.py
@@ -8,9 +8,8 @@ from requests import Response
 from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
-from bobweb.bob.command import ChatCommand
+from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob.command_dallemini import image_to_byte_array
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
 from bobweb.bob.utils_common import fitzstr_from, has, flatten
 
 logger = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ class EpicGamesOffersCommand(ChatCommand):
     def __init__(self):
         super(EpicGamesOffersCommand, self).__init__(
             name='epicgames',
-            regex=rf'(?i)^{PREFIXES_MATCHER}epicgames$',  # case insensitive
+            regex=regex_simple_command('epicgames'),
             help_text_short=('!epicgames', 'ilmaispelit')
         )
 

--- a/bobweb/bob/command_help.py
+++ b/bobweb/bob/command_help.py
@@ -5,15 +5,14 @@ from telegram.ext import CallbackContext
 from typing import List
 
 from bobweb.bob.utils_format import MessageArrayFormatter, Align
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
-from bobweb.bob.command import ChatCommand
+from bobweb.bob.command import ChatCommand, regex_simple_command
 
 
 class HelpCommand(ChatCommand):
     def __init__(self, other_commands):
         super().__init__(
             name='help',
-            regex=r'^' + PREFIXES_MATCHER + 'help$',
+            regex=regex_simple_command('help'),
             help_text_short=None
         )
         # Help text is formatted once and stored as attribute

--- a/bobweb/bob/command_help.py
+++ b/bobweb/bob/command_help.py
@@ -1,6 +1,6 @@
 import string
 
-from telegram import Update
+from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 from typing import List
 
@@ -20,7 +20,7 @@ class HelpCommand(ChatCommand):
         self.reply_text = create_reply_text(other_commands)
 
     def handle_update(self, update: Update, context: CallbackContext = None):
-        update.effective_message.reply_text(self.reply_text, parse_mode='Markdown', quote=False)
+        update.effective_message.reply_text(self.reply_text, parse_mode=ParseMode.MARKDOWN, quote=False)
 
 
 def create_reply_text(commands: List[ChatCommand]) -> string:

--- a/bobweb/bob/command_huoneilma.py
+++ b/bobweb/bob/command_huoneilma.py
@@ -19,8 +19,7 @@ if is_raspberrypi():
     GPIO.setmode(GPIO.BCM)
     import Adafruit_DHT
 
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_simple_command
 
 DHTSensor = 11  # same as 11
 humidity_sensor_gpio_pin_number = 17
@@ -30,7 +29,7 @@ class HuoneilmaCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='huoneilma',
-            regex=r'^' + PREFIXES_MATCHER + 'huoneilma',
+            regex=regex_simple_command('huoneilma'),
             help_text_short=('huoneilma', 'Näyttää sisälämpötilan ja ilmankosteuden "serverihuoneessa"')
         )
 

--- a/bobweb/bob/command_huutista.py
+++ b/bobweb/bob/command_huutista.py
@@ -8,7 +8,7 @@ class HuutistaCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='huutista',
-            regex=r'(?i)^huutista$',  # (?i) => case insensitive, $ => end of string
+            regex=r'(?i)^huutista$',  # Note! No command prefix, (?i) => case insensitive, $ => end of string
             help_text_short=('huutista', '😂')
         )
 

--- a/bobweb/bob/command_kunta.py
+++ b/bobweb/bob/command_kunta.py
@@ -11,7 +11,7 @@ from shapely.geometry import shape
 from shapely.geometry.multipolygon import MultiPolygon
 
 from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
-from telegram import Update
+from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
 from bobweb.bob.command import ChatCommand
@@ -71,7 +71,7 @@ def handle_image_generation_and_reply(update: Update, kunta_name: string, kunta_
         send_image_response(update, kunta_name, image_compilation)
 
     except ImageGenerationException as e:  # If exception was raised, reply its response_text
-        update.effective_message.reply_text(e.response_text, quote=True, parse_mode='Markdown')
+        update.effective_message.reply_text(e.response_text, quote=True, parse_mode=ParseMode.HTML)
 
 
 def generate_and_format_result_image(kunta_geo: MultiPolygon) -> Image:

--- a/bobweb/bob/command_kunta.py
+++ b/bobweb/bob/command_kunta.py
@@ -10,11 +10,10 @@ import folium
 from shapely.geometry import shape
 from shapely.geometry.multipolygon import MultiPolygon
 
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
 from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
-from bobweb.bob.command import ChatCommand
+from bobweb.bob.command import ChatCommand, regex_command_with_parameters
 
 from bobweb.bob.command_dallemini import ImageGenerationException, send_image_response
 
@@ -27,7 +26,7 @@ class KuntaCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='kunta',
-            regex=r'^' + PREFIXES_MATCHER + r'kunta($|\s)',
+            regex=regex_command_with_parameters('kunta'),
             help_text_short=('!kunta', 'Satunnainen kunta')
         )
         # Thanks to https://github.com/geoharo/Geokml

--- a/bobweb/bob/command_kunta.py
+++ b/bobweb/bob/command_kunta.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import string
 import json
 import random
@@ -30,8 +31,13 @@ class KuntaCommand(ChatCommand):
             help_text_short=('!kunta', 'Satunnainen kunta')
         )
         # Thanks to https://github.com/geoharo/Geokml
-        if os.path.isfile('bobweb/bob/resources/Kuntarajat.geojson'):
-            self.kuntarajat = json.loads(open('bobweb/bob/resources/Kuntarajat.geojson').read())['features']
+        # Check if current working directory and import geojson relatively to working directory
+        if re.search(r'bobweb[/\\]bob', os.getcwd()) is not None:
+            relative_geojson_path = 'resources/Kuntarajat.geojson'
+        else:
+            relative_geojson_path = 'bobweb/bob/resources/Kuntarajat.geojson'
+        self.kuntarajat = json.loads(open(relative_geojson_path).read())['features']
+
 
     def handle_update(self, update: Update, context: CallbackContext = None):
         self.kunta_command(update, context)

--- a/bobweb/bob/command_leet.py
+++ b/bobweb/bob/command_leet.py
@@ -13,7 +13,7 @@ class LeetCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='1337',
-            regex=r'^1337$',
+            regex=r'^1337$',  # Note! No command prefix
             help_text_short=('1337', 'Nopein ylenee')
         )
 

--- a/bobweb/bob/command_or.py
+++ b/bobweb/bob/command_or.py
@@ -13,7 +13,7 @@ class OrCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='vai',
-            regex=r'\s' + PREFIXES_MATCHER + r'vai\s',  # any text and whitespace before and after the command
+            regex=rf'\s{PREFIXES_MATCHER}vai\s',  # any text and whitespace before and after the command
             help_text_short=('.. !vai ..', 'Arpoo toisen')
         )
 

--- a/bobweb/bob/command_rules_of_acquisition.py
+++ b/bobweb/bob/command_rules_of_acquisition.py
@@ -1,14 +1,12 @@
 import logging
 import random
-import re
 
 from telegram import Update
 from telegram.ext import CallbackContext
 
 from bobweb.bob.resources import rules_of_acquisition
 
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_command_with_parameters
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +15,7 @@ class RulesOfAquisitionCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='sääntö',
-            regex=r'^' + PREFIXES_MATCHER + r'sääntö($|\s)',  # ($|\s) end of string or whitespace character
+            regex=regex_command_with_parameters('sääntö'),
             help_text_short=('!sääntö', '[nro]')
         )
 

--- a/bobweb/bob/command_ruoka.py
+++ b/bobweb/bob/command_ruoka.py
@@ -3,8 +3,7 @@ import random
 from telegram.ext import CallbackContext
 
 from bobweb.bob.resources.recipes import recipes
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_command_with_parameters
 from telegram import Update
 
 
@@ -12,7 +11,7 @@ class RuokaCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='ruoka',
-            regex=r'^' + PREFIXES_MATCHER + r'ruoka($|\s)',
+            regex=regex_command_with_parameters('ruoka'),
             help_text_short=('!ruoka', 'Ruokaresepti')
         )
 

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -20,7 +20,7 @@ from bobweb.bob.command_space import SpaceCommand
 from bobweb.bob.command_users import UsersCommand
 from bobweb.bob.command_weather import WeatherCommand
 from bobweb.bob.command_daily_question import DailyQuestionHandler, DailyQuestionCommand, MarkAnswerCommand
-from bobweb.bob.epic_games import EpicGamesOffersCommand
+from bobweb.bob.command_epic_games import EpicGamesOffersCommand
 from bobweb.bob.utils_common import has
 
 

--- a/bobweb/bob/command_settings.py
+++ b/bobweb/bob/command_settings.py
@@ -1,10 +1,9 @@
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import CallbackContext
 
-from bobweb.bob.activities.activity_state import ActivityState, cancel_button, back_button
+from bobweb.bob.activities.activity_state import ActivityState, back_button
 from bobweb.bob.activities.command_activity import CommandActivity
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob import database, command_service
 from bobweb.bob.utils_common import split_to_chunks
 from bobweb.web.bobapp.models import Chat
@@ -48,7 +47,7 @@ class SettingsCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='asetukset',
-            regex=r'(?i)^' + PREFIXES_MATCHER + r'asetukset$',
+            regex=regex_simple_command('asetukset'),
             help_text_short=('!asetukset', 'botin asetukset')
         )
 

--- a/bobweb/bob/command_space.py
+++ b/bobweb/bob/command_space.py
@@ -1,7 +1,7 @@
 from telegram.ext import CallbackContext
 
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER, DEFAULT_TIMEZONE
+from bobweb.bob.command import ChatCommand, regex_simple_command
+from bobweb.bob.resources.bob_constants import DEFAULT_TIMEZONE
 from telegram import Update
 from zoneinfo import ZoneInfo
 import requests
@@ -14,7 +14,7 @@ class SpaceCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='space',
-            regex=r'' + PREFIXES_MATCHER + 'space',
+            regex=regex_simple_command('space'),
             help_text_short=('!space', 'Seuraava laukaisu')
         )
 

--- a/bobweb/bob/command_users.py
+++ b/bobweb/bob/command_users.py
@@ -2,7 +2,7 @@ import sys
 from typing import List
 
 from telegram.ext import CallbackContext
-from telegram import Update
+from telegram import Update, ParseMode
 
 from bobweb.bob.utils_format import MessageArrayFormatter
 from bobweb.bob.command import ChatCommand
@@ -38,13 +38,14 @@ def users_command(update: Update):
 
     footer = 'A=Arvo, K=Kunnia, V=Viestit'
 
-    reply_text = '```\n' \
-                 + 'Käyttäjät \U0001F913\n\n' \
-                 + f'{formatted_members_array_str}\n' \
-                 + f'{footer}' \
-                 + '```'  # '\U0001F913' => nerd emoji, '```' =>  markdown code block
+    # '\U0001F913' => nerd emoji, '```' =>  markdown code block
+    reply_text = 'Käyttäjät \U0001F913\n\n' \
+                 + '```\n' \
+                 + f'{formatted_members_array_str}' \
+                 + f'```\n' \
+                 + f'{footer}'
 
-    update.effective_message.reply_text(reply_text, quote=False, parse_mode='Markdown')
+    update.effective_message.reply_text(reply_text, quote=False, parse_mode=ParseMode.MARKDOWN)
 
 
 def exclude_possible_bots(members: List[ChatMember]):

--- a/bobweb/bob/command_users.py
+++ b/bobweb/bob/command_users.py
@@ -5,8 +5,7 @@ from telegram.ext import CallbackContext
 from telegram import Update, ParseMode
 
 from bobweb.bob.utils_format import MessageArrayFormatter
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob import database
 
 from bobweb.web.bobapp.models import ChatMember
@@ -16,7 +15,7 @@ class UsersCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='käyttäjät',
-            regex=r'^' + PREFIXES_MATCHER + 'käyttäjät$',  # '^' = Start of string, '$' = end of sting
+            regex=regex_simple_command('käyttäjät'),
             help_text_short=('!käyttäjät', 'Lista käyttäjistä')
         )
 

--- a/bobweb/bob/command_weather.py
+++ b/bobweb/bob/command_weather.py
@@ -8,8 +8,7 @@ from telegram.ext import CallbackContext
 
 from bobweb.bob import database
 
-from bobweb.bob.command import ChatCommand
-from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
+from bobweb.bob.command import ChatCommand, regex_command_with_parameters
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ class WeatherCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='sää',
-            regex=r'^' + PREFIXES_MATCHER + r'sää($|\s)',
+            regex=regex_command_with_parameters('sää'),
             help_text_short=('!sää', '[kaupunki]:n sää')
         )
 

--- a/bobweb/bob/epic_games.py
+++ b/bobweb/bob/epic_games.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import requests
 from PIL import Image
 from requests import Response
-from telegram import Update
+from telegram import Update, ParseMode
 from telegram.ext import CallbackContext
 
 from bobweb.bob.command import ChatCommand
@@ -30,9 +30,9 @@ class EpicGamesOffersCommand(ChatCommand):
         try:
             msg, image_bytes = create_free_games_announcement_msg()
             if has(image_bytes):
-                update.effective_message.reply_photo(photo=image_bytes, caption=msg, parse_mode='html', quote=False)
+                update.effective_message.reply_photo(photo=image_bytes, caption=msg, parse_mode=ParseMode.HTML, quote=False)
             else:
-                update.effective_message.reply_text(text=msg, parse_mode='html', quote=False)
+                update.effective_message.reply_text(text=msg, parse_mode=ParseMode.HTML, quote=False)
         except Exception as e:
             logger.error(e)
             update.effective_message.reply_text(fetch_failed_msg, quote=False)

--- a/bobweb/bob/scheduler.py
+++ b/bobweb/bob/scheduler.py
@@ -3,6 +3,7 @@ import logging
 import aiocron
 import asyncio
 
+from telegram import ParseMode
 from telegram.ext import Updater
 import signal  # Keyboard interrupt listening for Windows
 
@@ -61,9 +62,10 @@ class Scheduler:
             for chat in chats:
                 try:
                     if has(image_bytes):
-                        self.updater.bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=msg, parse_mode='html')
+                        self.updater.bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=msg,
+                                                    parse_mode=ParseMode.HTML)
                     else:
-                        self.updater.bot.send_message(chat_id=chat.id, text=msg, parse_mode='html')
+                        self.updater.bot.send_message(chat_id=chat.id, text=msg, parse_mode=ParseMode.HTML)
                 except Exception as e:
                     logger.error(e)
                     self.updater.bot.send_message(chat_id=chat.id, text=fetch_failed_msg)

--- a/bobweb/bob/scheduler.py
+++ b/bobweb/bob/scheduler.py
@@ -13,7 +13,7 @@ from bobweb.bob.utils_common import has
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-from bobweb.bob import main, database
+from bobweb.bob import database, broadcaster
 from bobweb.bob import db_backup
 
 logger = logging.getLogger(__name__)
@@ -52,20 +52,22 @@ class Scheduler:
     async def friday_noon(self):
         # TODO: Perjantain rankkien lähetys
         await db_backup.create(self.updater.bot)
-        await main.broadcast(self.updater.bot, "Jahas, työviikko taas pulkassa,,,")
+        await broadcaster.broadcast(self.updater.bot, "Jahas, työviikko taas pulkassa,,,")
 
     async def announce_free_epic_games_store_games(self):
-        chats = [x for x in database.get_chats() if x.free_game_offers_enabled]
-        if len(chats) > 0:
-            msg, image_bytes = create_free_games_announcement_msg()
+        chats_with_announcement_on = [x for x in database.get_chats() if x.free_game_offers_enabled]
+        if len(chats_with_announcement_on) == 0:
+            return  # Early return if no chats with
 
-            for chat in chats:
-                try:
-                    if has(image_bytes):
-                        self.updater.bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=msg,
-                                                    parse_mode=ParseMode.HTML)
-                    else:
-                        self.updater.bot.send_message(chat_id=chat.id, text=msg, parse_mode=ParseMode.HTML)
-                except Exception as e:
-                    logger.error(e)
-                    self.updater.bot.send_message(chat_id=chat.id, text=fetch_failed_msg)
+        # Define either announcement message and possible game images or fetch_failed_msg without image
+        try:
+            msg, image_bytes = create_free_games_announcement_msg()
+        except Exception as e:
+            msg, image_bytes = fetch_failed_msg, None
+            logger.error(e)
+
+        for chat in chats_with_announcement_on:
+            if has(image_bytes):
+                self.updater.bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=msg, parse_mode=ParseMode.HTML)
+            else:
+                self.updater.bot.send_message(chat_id=chat.id, text=msg, parse_mode=ParseMode.HTML)

--- a/bobweb/bob/scheduler.py
+++ b/bobweb/bob/scheduler.py
@@ -7,7 +7,7 @@ from telegram import ParseMode
 from telegram.ext import Updater
 import signal  # Keyboard interrupt listening for Windows
 
-from bobweb.bob.epic_games import create_free_games_announcement_msg, fetch_failed_msg
+from bobweb.bob.command_epic_games import create_free_games_announcement_msg, fetch_failed_msg
 from bobweb.bob.resources.bob_constants import fitz
 from bobweb.bob.utils_common import has
 

--- a/bobweb/bob/test/daily_question/test_dq_command_activities.py
+++ b/bobweb/bob/test/daily_question/test_dq_command_activities.py
@@ -21,10 +21,11 @@ from bobweb.bob.activities.daily_question.end_season_states import end_season_no
     no_dq_season_deleted_msg, end_season_cancelled, end_anyway_btn
 from bobweb.bob.activities.daily_question.start_season_states import get_message_body, get_season_created_msg, \
     start_season_cancelled
+from bobweb.bob.command_daily_question import DailyQuestionCommand
 from bobweb.bob.test.daily_question.utils import go_to_seasons_menu_v2, \
     populate_season_with_dq_and_answer_v2, populate_season_v2, kysymys_command, go_to_stats_menu_v2
 from bobweb.bob.tests_mocks_v2 import MockChat, init_chat_user, MockUser
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
+from bobweb.bob.tests_utils import assert_command_triggers
 from bobweb.bob.tests_msg_btn_utils import button_labels_from_reply_markup
 from bobweb.web.bobapp.models import DailyQuestionSeason, DailyQuestion, DailyQuestionAnswer
 from bobweb.bob.activities.activity_state import back_button, cancel_button
@@ -38,11 +39,10 @@ class DailyQuestionTestSuiteV2(TestCase):
         django.setup()
         os.system("python ../web/manage.py migrate")
 
-    def test_should_reply_to_question_commands_case_insenstivite_all_prefixes(self):
-        assert_has_reply_to(self, "/kysymys")
-        assert_has_reply_to(self, "!KYSymys")
-        assert_no_reply_to(self, ".kysymys kausi")
-        assert_no_reply_to(self, "asd .kysymys")
+    def test_command_triggers(self):
+        should_trigger = ['/kysymys', '!kysymys', '.kysymys', '/KYSYMYS']
+        should_not_trigger = ['kysymys', 'test /kysymys', '/kysymys test']
+        assert_command_triggers(self, DailyQuestionCommand, should_trigger, should_not_trigger)
 
     #
     # Daily Question Seasons - Menu

--- a/bobweb/bob/test/daily_question/test_dq_questions_and_answers.py
+++ b/bobweb/bob/test/daily_question/test_dq_questions_and_answers.py
@@ -7,10 +7,10 @@ from django.test import TestCase
 from freezegun import freeze_time
 
 from bobweb.bob.activities.daily_question.message_utils import dq_created_from_msg_edit
-from bobweb.bob.command_daily_question import no_answer_found_for_last_dq_msg
+from bobweb.bob.command_daily_question import no_answer_found_for_last_dq_msg, DailyQuestionHandler
 from bobweb.bob.test.daily_question.utils import populate_season_v2, populate_season_with_dq_and_answer_v2
 from bobweb.bob.tests_mocks_v2 import MockMessage, MockChat, init_chat_user, MockUser
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
+from bobweb.bob.tests_utils import assert_command_triggers
 from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer
 
 
@@ -22,16 +22,11 @@ class DailyQuestionTestSuiteV2(TestCase):
         django.setup()
         os.system("python ../web/manage.py migrate")
 
-    def test_should_reply_when_question_hashtag_anywhere_in_text(self):
-        assert_has_reply_to(self, "#päivänkysymys")
-        assert_has_reply_to(self, "asd\nasd #päivänkysymys")
-        assert_has_reply_to(self, "#päivänkysymys asd\nasd")
-        assert_has_reply_to(self, "asd\nasd #päivänkysymys asd\nasd")
-
-    def test_no_prefix_no_reply_to_question_text_without_hashtag(self):
-        assert_no_reply_to(self, "päivänkysymys")
-        assert_no_reply_to(self, "/päivänkysymys")
-        assert_no_reply_to(self, "/päivänkys")
+    def test_command_triggers(self):
+        should_trigger = ['#päivänkysymys', 'asd\nasd #päivänkysymys', '#päivänkysymys asd\nasd',
+                          'asd\nasd #päivänkysymys asd\nasd ', '#PÄIVÄNKYSYMYS ???']
+        should_not_trigger = ['päivänkysymys', '/päivänkysymys', '/päivänkys', '# päivänkys']
+        assert_command_triggers(self, DailyQuestionHandler, should_trigger, should_not_trigger)
 
     #
     # Daily Questions

--- a/bobweb/bob/test/daily_question/test_mark_answer_command.py
+++ b/bobweb/bob/test/daily_question/test_mark_answer_command.py
@@ -6,12 +6,13 @@ from freezegun import freeze_time
 from bobweb.bob import main  # needed to not cause circular import
 from django.test import TestCase
 
-from bobweb.bob.command_daily_question import target_msg_saved_as_winning_answer_msg, target_msg_saved_as_answer_msg
+from bobweb.bob.command_daily_question import target_msg_saved_as_winning_answer_msg, target_msg_saved_as_answer_msg, \
+    MarkAnswerCommand
 from bobweb.bob.test.daily_question.test_dq_questions_and_answers import \
     assert_winner_not_set_no_answer_to_last_dq_from_author
 from bobweb.bob.test.daily_question.utils import populate_season_with_dq_and_answer_v2
 from bobweb.bob.tests_mocks_v2 import init_chat_user, MockUser
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
+from bobweb.bob.tests_utils import assert_command_triggers
 from bobweb.web.bobapp.models import DailyQuestionAnswer
 
 
@@ -26,12 +27,11 @@ class DailyQuestionTestSuiteV2(TestCase):
         django.setup()
         os.system("python ../web/manage.py migrate")
 
-    def test_should_reply_to_question_commands_case_insenstivite_all_prefixes(self):
-        assert_has_reply_to(self, answer_command_msg)
-        assert_has_reply_to(self, "!VAStaus")
-        assert_has_reply_to(self, ".vastaus")
-        assert_no_reply_to(self, ".vastaus 2000-01-01")
-        assert_no_reply_to(self, "asd .vastaus")
+    def test_command_triggers(self):
+        should_trigger = [answer_command_msg, '!vastaus', '.vastaus', answer_command_msg.capitalize()]
+        should_not_trigger = ['vastaus', 'test /vastaus', '/vastaus test']
+        assert_command_triggers(self, MarkAnswerCommand, should_trigger, should_not_trigger)
+
 
     def test_message_is_saved_as_answer_when_replied_with_mark_command(self):
         chat, user = init_chat_user()

--- a/bobweb/bob/test_command_asetukset.py
+++ b/bobweb/bob/test_command_asetukset.py
@@ -6,10 +6,11 @@ from django.test import TestCase
 
 from bobweb.bob import main, database
 from bobweb.bob.activities.activity_state import back_button
+from bobweb.bob.command_settings import SettingsCommand
 
 from bobweb.bob.tests_mocks_v2 import init_chat_user
-from bobweb.bob.tests_msg_btn_utils import buttons_from_reply_markup, button_labels_from_reply_markup
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
+from bobweb.bob.tests_msg_btn_utils import button_labels_from_reply_markup
+from bobweb.bob.tests_utils import assert_command_triggers
 
 import django
 
@@ -35,17 +36,10 @@ class SettingsCommandTests(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply_and_is_case_insensitive(self):
-        assert_has_reply_to(self, settings_command)
-        assert_has_reply_to(self, '.ASETukset')
-        assert_has_reply_to(self, '!asetukSET')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'asetukset')
-
-    def test_text_before_or_after_command_no_reply(self):
-        assert_no_reply_to(self, 'test /asetukset')
-        assert_no_reply_to(self, '/asetukset test')
+    def test_command_triggers(self):
+        should_trigger = [settings_command, '!asetukset', '.asetukset', settings_command.capitalize()]
+        should_not_trigger = ['asetukset', 'test /asetukset', '/asetukset test']
+        assert_command_triggers(self, SettingsCommand, should_trigger, should_not_trigger)
 
     def test_pressing_button_toggles_property(self):
         chat, user = init_chat_user()

--- a/bobweb/bob/test_command_dallemini.py
+++ b/bobweb/bob/test_command_dallemini.py
@@ -10,8 +10,9 @@ from PIL.JpegImagePlugin import JpegImageFile
 
 from bobweb.bob import main
 from bobweb.bob.tests_mocks_v1 import MockUpdate
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain, \
-    mock_response_with_code, assert_reply_equal, MockResponse, assert_get_parameters_returns_expected_value
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    mock_response_with_code, assert_reply_equal, MockResponse, assert_get_parameters_returns_expected_value, \
+    assert_command_triggers
 
 from bobweb.bob.command_dallemini import convert_base64_strings_to_images, get_3x3_image_compilation, send_image_response, \
      get_image_file_name, DalleMiniCommand
@@ -41,17 +42,10 @@ class Test(IsolatedAsyncioTestCase):
         os.system("python bobweb/web/manage.py migrate")
         DalleMiniCommand.run_async = False
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, '/dallemini')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'dallemini')
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, 'test /dallemini')
-
-    def test_text_after_command_should_reply(self):
-        assert_has_reply_to(self, '/dallemini test')
+    def test_command_triggers(self):
+        should_trigger = ['/dallemini', '!dallemini', '.dallemini', '/DALLEMINI', '/dallemini test']
+        should_not_trigger = ['dallemini', 'test /dallemini']
+        assert_command_triggers(self, DalleMiniCommand, should_trigger, should_not_trigger)
 
     def test_no_prompt_gives_help_reply(self):
         assert_reply_equal(self, '/dallemini', "Anna jokin syöte komennon jälkeen. '[.!/]prompt [syöte]'")

--- a/bobweb/bob/test_command_dallemini.py
+++ b/bobweb/bob/test_command_dallemini.py
@@ -57,7 +57,7 @@ class Test(IsolatedAsyncioTestCase):
         assert_reply_equal(self, '/dallemini', "Anna jokin syöte komennon jälkeen. '[.!/]prompt [syöte]'")
 
     def test_reply_contains_given_prompt_in_italics_and_quotes(self):
-        assert_reply_to_contain(self, '/dallemini 1337', ['"_1337_"'])
+        assert_reply_to_contain(self, '/dallemini 1337', ['"<i>1337</i>"'])
 
     def test_response_status_not_200_gives_error_msg(self):
         with mock.patch('requests.post', mock_response_with_code(403)):
@@ -74,7 +74,7 @@ class Test(IsolatedAsyncioTestCase):
         send_image_response(update, prompt, expected_image)
 
         # Message text should be in quotes and in italics
-        self.assertEqual('"_test_"', update.effective_message.reply_message_text)
+        self.assertEqual('"<i>test</i>"', update.effective_message.reply_message_text)
 
         actual_image_bytes = update.effective_message.reply_image.field_tuple[1]
         actual_image_stream = io.BytesIO(actual_image_bytes)

--- a/bobweb/bob/test_command_help.py
+++ b/bobweb/bob/test_command_help.py
@@ -6,10 +6,12 @@ from bobweb.bob import main, command_service
 from django.test import TestCase
 
 from bobweb.bob import message_handler
+from bobweb.bob.command_help import HelpCommand
 from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
 from bobweb.bob.tests_mocks_v1 import MockUpdate
 
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    assert_command_triggers
 
 
 class Test(TestCase):
@@ -19,17 +21,10 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, "/help")
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, "help")
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, "test /help")
-
-    def test_text_after_command_no_reply(self):
-        assert_no_reply_to(self, "/help test")
+    def test_command_triggers(self):
+        should_trigger = ['/help', '!help', '.help', '/HELP']
+        should_not_trigger = ['help', 'test /help', '/help test']
+        assert_command_triggers(self, HelpCommand, should_trigger, should_not_trigger)
 
     def test_contains_heading_and_footer(self):
         message_start = ['Bob-botti osaa auttaa ainakin seuraavasti']

--- a/bobweb/bob/test_command_huoneilma.py
+++ b/bobweb/bob/test_command_huoneilma.py
@@ -3,19 +3,15 @@ from unittest import mock
 from django.test import TestCase
 
 
-from bobweb.bob.command_huoneilma import interpret_measurement
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_equal
+from bobweb.bob.command_huoneilma import interpret_measurement, HuoneilmaCommand
+from bobweb.bob.tests_utils import assert_reply_equal, assert_command_triggers
 
 
 class Test(TestCase):
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, "/huoneilma")
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, "huoneilma on tosi hyvä")
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, "tunkkainen /huoneilma")
+    def test_command_triggers(self):
+        should_trigger = ['/huoneilma', '!huoneilma', '.huoneilma', '/HUONEILMA']
+        should_not_trigger = ['huoneilma', '/huoneilma test', 'huoneilma on tosi hyvä', 'tunkkainen /huoneilma']
+        assert_command_triggers(self, HuoneilmaCommand, should_trigger, should_not_trigger)
 
     def test_failed_measurement_response(self):
         response = interpret_measurement(None, None)

--- a/bobweb/bob/test_command_kunta.py
+++ b/bobweb/bob/test_command_kunta.py
@@ -5,7 +5,7 @@ from unittest import IsolatedAsyncioTestCase, mock
 from PIL import Image
 
 from bobweb.bob.command_kunta import KuntaCommand
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to
+from bobweb.bob.tests_utils import assert_command_triggers
 
 import django
 
@@ -29,17 +29,7 @@ class Test(IsolatedAsyncioTestCase):
         os.system("python bobweb/web/manage.py migrate")
         KuntaCommand.run_async = False
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, '/kunta')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'kunta')
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, 'test /kunta')
-
-    def test_text_after_command_should_reply(self):
-        assert_has_reply_to(self, '/kunta test')
-
-    def test_no_prompt_should_reply(self):
-        assert_has_reply_to(self, '/kunta')
+    def test_command_triggers(self):
+        should_trigger = ['/kunta', '!kunta', '.kunta', '/KUNTA', '/kunta test']
+        should_not_trigger = ['kunta', 'test /kunta']
+        assert_command_triggers(self, KuntaCommand, should_trigger, should_not_trigger)

--- a/bobweb/bob/test_command_or.py
+++ b/bobweb/bob/test_command_or.py
@@ -6,8 +6,8 @@ from unittest import mock
 
 from bobweb.bob import main
 from bobweb.bob.command_or import OrCommand
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain, always_last_choice, \
-    assert_reply_equal
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    assert_reply_equal, assert_command_triggers
 
 
 @mock.patch('random.choice', lambda values: values[0])
@@ -18,18 +18,11 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_no_parameter_before_or_after_should_not_reply(self):
-        assert_no_reply_to(self, '/vai')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'vai')
-
-    def test_only_one_parameter_should_not_reply(self):
-        assert_no_reply_to(self, 'test /vai')
-        assert_no_reply_to(self, '/vai test')
-
-    def test_parameter_before_and_after_should_reply(self):
-        assert_has_reply_to(self, 'test .vai test')
+    def test_command_triggers(self):
+        # Should have some text before and after the command
+        should_trigger = ['test /vai test', 'test !vai test', 'test .vai test']
+        should_not_trigger = ['vai', '/vai', 'test /vai', '/vai test']
+        assert_command_triggers(self, OrCommand, should_trigger, should_not_trigger)
 
     def test_get_given_parameter(self):
         message = 'a !vai b .vai c /vai d'

--- a/bobweb/bob/test_command_rules_of_acquisition.py
+++ b/bobweb/bob/test_command_rules_of_acquisition.py
@@ -5,7 +5,9 @@ from django.test import TestCase
 from unittest import mock
 
 from bobweb.bob import main
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain
+from bobweb.bob.command_rules_of_acquisition import RulesOfAquisitionCommand
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    assert_command_triggers
 
 
 class Test(TestCase):
@@ -15,17 +17,10 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, '/sääntö')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'sääntö')
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, 'test /sääntö')
-
-    def test_text_after_command_should_reply(self):
-        assert_has_reply_to(self, '/sääntö test')
+    def test_command_triggers(self):
+        should_trigger = ['/sääntö', '!sääntö', '.sääntö', '/SÄÄNTÖ', '/sääntö test']
+        should_not_trigger = ['sääntö', 'test /sääntö']
+        assert_command_triggers(self, RulesOfAquisitionCommand, should_trigger, should_not_trigger)
 
     @mock.patch('random.choice', lambda values: values[0])
     def test_without_number_should_return_random_rule(self):

--- a/bobweb/bob/test_command_ruoka.py
+++ b/bobweb/bob/test_command_ruoka.py
@@ -6,8 +6,8 @@ from unittest import mock
 
 from bobweb.bob import main
 from bobweb.bob.command_ruoka import RuokaCommand
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain, \
-    assert_get_parameters_returns_expected_value
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    assert_get_parameters_returns_expected_value, assert_command_triggers
 
 
 @mock.patch('random.choice', lambda values: values[0])
@@ -18,17 +18,10 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, '/ruoka')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'ruoka')
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, 'test /ruoka')
-
-    def test_text_after_command_should_reply(self):
-        assert_has_reply_to(self, '/ruoka test')
+    def test_command_triggers(self):
+        should_trigger = ['/ruoka', '!ruoka', '.ruoka', '/RUOKA', '/ruoka test']
+        should_not_trigger = ['ruoka', 'test /ruoka', ]
+        assert_command_triggers(self, RuokaCommand, should_trigger, should_not_trigger)
 
     def test_get_given_parameter(self):
         assert_get_parameters_returns_expected_value(self, '!ruoka', RuokaCommand())

--- a/bobweb/bob/test_command_users.py
+++ b/bobweb/bob/test_command_users.py
@@ -6,9 +6,9 @@ from django.test import TestCase
 from unittest import mock
 
 from bobweb.bob.utils_format import transpose, MessageArrayFormatter
-from bobweb.bob.command_users import create_member_array
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain, \
-    assert_reply_to_not_contain
+from bobweb.bob.command_users import create_member_array, UsersCommand
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    assert_reply_to_not_contain, assert_command_triggers
 
 from bobweb.web.bobapp.models import ChatMember
 
@@ -20,17 +20,10 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, "/käyttäjät")
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, "käyttäjät")
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, "test /käyttäjät")
-
-    def test_text_after_command_no_reply(self):
-        assert_no_reply_to(self, "/käyttäjät test")
+    def test_command_triggers(self):
+        should_trigger = ['/käyttäjät', '!käyttäjät', '.käyttäjät', '/KÄYTTÄJÄT']
+        should_not_trigger = ['käyttäjät', 'test /käyttäjät', '/help käyttäjät']
+        assert_command_triggers(self, UsersCommand, should_trigger, should_not_trigger)
 
     def test_contains_heading_and_footer(self):
         message_start = ['Käyttäjät \U0001F913\n\n']

--- a/bobweb/bob/test_command_weather.py
+++ b/bobweb/bob/test_command_weather.py
@@ -8,8 +8,8 @@ from unittest.mock import Mock
 from bobweb.bob import main
 from bobweb.bob.command_weather import WeatherCommand
 from bobweb.bob.resources.test.weather_mock_data import helsinki_weather, turku_weather
-from bobweb.bob.tests_utils import assert_has_reply_to, assert_no_reply_to, assert_reply_to_contain, \
-    MockResponse, mock_response_with_code, assert_get_parameters_returns_expected_value
+from bobweb.bob.tests_utils import assert_reply_to_contain, \
+    MockResponse, mock_response_with_code, assert_get_parameters_returns_expected_value, assert_command_triggers
 from bobweb.web.bobapp.models import ChatMember
 
 
@@ -26,17 +26,10 @@ class Test(TestCase):
         django.setup()
         os.system("python bobweb/web/manage.py migrate")
 
-    def test_command_should_reply(self):
-        assert_has_reply_to(self, '/sää')
-
-    def test_no_prefix_no_reply(self):
-        assert_no_reply_to(self, 'sää')
-
-    def test_text_before_command_no_reply(self):
-        assert_no_reply_to(self, 'test /sää')
-
-    def test_text_after_command_should_reply(self):
-        assert_has_reply_to(self, '/sää test')
+    def test_command_triggers(self):
+        should_trigger = ['/sää', '!sää', '.sää', '/SÄÄ', '/sää test']
+        should_not_trigger = ['sää', 'test /sää']
+        assert_command_triggers(self, WeatherCommand, should_trigger, should_not_trigger)
 
     def test_get_given_parameter(self):
         assert_get_parameters_returns_expected_value(self, '!sää', WeatherCommand())

--- a/bobweb/bob/test_main.py
+++ b/bobweb/bob/test_main.py
@@ -10,6 +10,7 @@ from unittest.mock import patch, Mock
 
 from bobweb.bob.activities.activity_state import ActivityState
 from bobweb.bob.command import ChatCommand
+from bobweb.bob.command_aika import AikaCommand
 from bobweb.bob.command_or import OrCommand
 from bobweb.bob.command_space import SpaceCommand
 from bobweb.bob.tests_mocks_v1 import MockUpdate, MockBot, MockUser, MockChat, MockMessage
@@ -25,7 +26,7 @@ from bobweb.bob import database
 import django
 
 from bobweb.bob.tests_mocks_v2 import init_chat_user
-from bobweb.bob.tests_utils import mock_random_with_delay
+from bobweb.bob.tests_utils import mock_random_with_delay, assert_command_triggers
 from bobweb.bob.utils_common import weekday_count_between, next_weekday, prev_weekday, split_to_chunks, flatten
 
 os.environ.setdefault(
@@ -152,6 +153,11 @@ class Test(IsolatedAsyncioTestCase):
         # Now as OrCommand is handled asynchronously, leet-command should be resolved first
         self.assertIn('Alokasvirhe!', chat.bot.messages[-2].text)
         self.assertEqual('1', chat.bot.messages[-1].text)
+
+    def test_aika_command_triggers(self):
+        should_trigger = ['/aika', '!aika', '.aika', '/Aika', '/aikA']
+        should_not_trigger = ['aika', '.aikamoista', 'asd /aika', '/aika asd']
+        assert_command_triggers(self, AikaCommand, should_trigger, should_not_trigger)
 
     def test_time_command(self):
         update = MockUpdate()

--- a/bobweb/bob/tests_utils.py
+++ b/bobweb/bob/tests_utils.py
@@ -63,20 +63,6 @@ command_should_not_trigger_fail_msg_template = \
     'command\'s handler.\nExpected behavior: message_handler should not be called for this message'
 
 
-# Bob should not reply to given message
-def assert_no_reply_to(test: TestCase, message_text: string):
-    update = MockUpdate().send_text(message_text)
-    reply = update.effective_message.reply_message_text
-    test.assertIsNone(reply)
-
-
-def assert_no_reply_to_v2(test: TestCase, message_text: string):
-    chat, user = init_chat_user()
-    user.send_message(message_text)
-    time.sleep(0.01)
-    test.assertEqual(0, len(chat.bot.messages))
-
-
 # Bobs message should contain all given elements in the list
 def assert_reply_to_contain(test: TestCase, message_text: string, expected_list: List[str]):
     update = MockUpdate().send_text(message_text)


### PR DESCRIPTION
Improved parse_mode usage and fixed bug where bob could not display d…
…q stats menu, if leading user in score had markdown element start character in name:

- Problem: parse_mode=MARKDOWN was used by default every time when bob edited an activity host message
- Solution: Moved responsibility of defining parse mode to the caller of 'reply_or_update_host_message' and removed redundant markdown definition from calls (cause of the bug)
- Improvement:
    - command_activity: rename variables in command_activity ('msg' -> 'text' as 'msg' could mean Telegram Message object) and implicated private methods with double underscore
    - Switched all string literal 'Markdown' to constant values from telegram package
    - changed user-message to only have the table wrapped in a code block (same as with dq stats message)
    - dallemini given image caption is now escaped, so special characters won't affect parsing


Improved command triggers and fixed bug where AikaCommand would trigg…
…er when it should not:

- Problem: Different chat_command subclasses had varying regex-matchers for trigger and AikaCommand's trigger did trigger if it was anywhere in the message (for example '.aikamoista' triggered the command)
- Solution: Added requirement, that message should start with '/aika' and only contain it to trigger
- Improvement:
    - Implemented and adopted methods 'regex_simple_command' and 'regex_command_with_parameters' to module command.py. These methods return a unified regex mather so that each ChatCommand subclass does not need to contain details of the regex matcher (exceptions: vai, 1337 and huutista, that have special trigger rules)
    - renamed module 'epic_games' -> 'command_epic_games'. Contains chat_command so might as well use same naming convention than other command modules
    - Created 'assert_command_triggers' method to test_utils.py that makes it easy and fast to test any commands triggering on different messages. Actual handling is replaced with mock which makes this faster. Now all trigger tests are using this new method and old ones have been removed.


Fixed bug where epic games cron job broadcast would fail silently:
- Problem: if timed cron job epic games fetch or data processing failed in any way, bot would fail silently and not broadcast error message
- Solution: refactored implementation so that error message is now sent on epic games cron job broadcast


Fixed bug where dq date confirmation had buttons next to each other r…
…esulting to all text in labels not showing:
- Buttons set to be on top of each other


Improved bot settings menu:
- Now has better help text that states that settings are saved instantly and not after the menu is hid. Bots messages are chatType aware (private/group)
- Now after setting menu is hid, changed settings are listed in the message and the settings menu can be reopened by a button