### PR TITLE
1337 uses Telegrams server time

### DIFF
--- a/bobweb/bob/command_leet.py
+++ b/bobweb/bob/command_leet.py
@@ -7,6 +7,7 @@ from telegram import Update
 
 from bobweb.bob.resources.bob_constants import fitz
 from bobweb.bob.ranks import promote, demote
+from bobweb.bob.utils_common import fitz_from
 
 
 class LeetCommand(ChatCommand):
@@ -25,14 +26,15 @@ class LeetCommand(ChatCommand):
 
 
 def leet_command(update: Update):
-    now = datetime.datetime.now(fitz)
     chat = database.get_chat(update.effective_chat.id)
     sender = database.get_chat_member(chat_id=update.effective_chat.id,
                                       tg_user_id=update.effective_user.id)
-    if chat.latest_leet != now.date() and \
-            now.hour == 13 and \
-            now.minute == 37:
-        chat.latest_leet = now.date()
+    # Message received datetime (determined by Telegram) in Finnish time zone
+    msg_dt_fi_tz = fitz_from(update.effective_message.date)
+    if chat.latest_leet != msg_dt_fi_tz.date() and \
+            msg_dt_fi_tz.hour == 13 and \
+            msg_dt_fi_tz.minute == 37:
+        chat.latest_leet = msg_dt_fi_tz.date()
         chat.save()
         reply_text = promote(sender)
     else:

--- a/bobweb/bob/test_time_utilities.py
+++ b/bobweb/bob/test_time_utilities.py
@@ -1,0 +1,112 @@
+import datetime
+
+import pytz
+from django.test import TestCase
+
+from bobweb.bob.resources.bob_constants import fitz
+from bobweb.bob.utils_common import next_weekday, prev_weekday, weekday_count_between, fitz_from
+
+
+class TimeUtilitiesTests(TestCase):
+
+    def test_next_weekday(self):
+        dt = datetime.datetime
+        self.assertEqual(dt(2000, 1,  3), next_weekday(dt(2000, 1, 1)))  # sat
+        self.assertEqual(dt(2000, 1,  3), next_weekday(dt(2000, 1, 2)))  # sun
+        self.assertEqual(dt(2000, 1,  4), next_weekday(dt(2000, 1, 3)))
+        self.assertEqual(dt(2000, 1,  5), next_weekday(dt(2000, 1, 4)))
+        self.assertEqual(dt(2000, 1,  6), next_weekday(dt(2000, 1, 5)))
+        self.assertEqual(dt(2000, 1,  7), next_weekday(dt(2000, 1, 6)))
+        self.assertEqual(dt(2000, 1, 10), next_weekday(dt(2000, 1, 7)))  # fri
+
+    def test_prev_weekday(self):
+        dt = datetime.datetime
+        self.assertEqual(dt(1999, 12, 31), prev_weekday(dt(2000, 1, 1)))  # sat
+        self.assertEqual(dt(1999, 12, 31), prev_weekday(dt(2000, 1, 2)))  # sun
+        self.assertEqual(dt(1999, 12, 31), prev_weekday(dt(2000, 1, 3)))
+        self.assertEqual(dt(2000,  1,  3), prev_weekday(dt(2000, 1, 4)))
+        self.assertEqual(dt(2000,  1,  4), prev_weekday(dt(2000, 1, 5)))
+        self.assertEqual(dt(2000,  1,  5), prev_weekday(dt(2000, 1, 6)))
+        self.assertEqual(dt(2000,  1,  6), prev_weekday(dt(2000, 1, 7)))  # fri
+
+    def test_get_weekday_count_between_2_days(self):
+        dt = datetime.datetime
+        between = weekday_count_between
+
+        # 2022-01-01 is saturday
+        self.assertEqual(0, between(dt(2000, 1, 1), dt(2000, 1, 1)))  # sat -> sat
+        self.assertEqual(0, between(dt(2000, 1, 1), dt(2000, 1, 2)))  # sat -> sun
+        # sat -> mon -  NOTE: as end date is not included, 0 week days
+        self.assertEqual(0, between(dt(2000, 1, 1), dt(2000, 1, 3)))
+        # sat -> tue - NOTE: monday is the only weekday in range
+        self.assertEqual(1, between(dt(2000, 1, 1), dt(2000, 1, 4)))
+        self.assertEqual(2, between(dt(2000, 1, 1), dt(2000, 1, 5)))
+        self.assertEqual(3, between(dt(2000, 1, 1), dt(2000, 1, 6)))
+        self.assertEqual(4, between(dt(2000, 1, 1), dt(2000, 1, 7)))
+        self.assertEqual(5, between(dt(2000, 1, 1), dt(2000, 1, 8)))
+        self.assertEqual(5, between(dt(2000, 1, 1), dt(2000, 1, 9)))
+        self.assertEqual(5, between(dt(2000, 1, 1), dt(2000, 1, 10)))
+        self.assertEqual(6, between(dt(2000, 1, 1), dt(2000, 1, 11)))
+
+        # end date is not inclueded
+        self.assertEqual(0, between(dt(2000, 1, 3), dt(2000, 1, 3)))
+        self.assertEqual(1, between(dt(2000, 1, 3), dt(2000, 1, 4)))
+
+        # order of dates does not matter
+        self.assertEqual(6, between(dt(2000, 1, 11), dt(2000, 1, 1)))
+
+        # Note, year cannot have less than 260 week days or more than 262
+        # 366 day year starting on saturday will end on saturday.
+        # More info https://en.wikipedia.org/wiki/Common_year_starting_on_Saturday
+        self.assertEqual(260, between(dt(2000, 1, 1), dt(2001, 1, 1)))  # 365 days. 53 saturdays and sundays
+        self.assertEqual(261, between(dt(2001, 1, 1), dt(2002, 1, 1)))  # 365 days, 52 saturdays and sundays
+        self.assertEqual(262, between(dt(2004, 1, 1), dt(2005, 1, 1)))  # 366 days, 52 saturdays and sundays
+
+
+class TestFitzFrom(TestCase):
+
+    def test_none_input(self):
+        self.assertIsNone(fitz_from(None))
+
+    def test_standard_time(self):
+        # Finnish standard time is UTC+02:00
+        # 21.11.2022, 15:30 UTC
+        dt = pytz.UTC.localize(datetime.datetime(2022, 11, 21, 15, 30))
+        # 21.11.2022, 17:30 Finnish TZ
+        expected_result = fitz.localize(datetime.datetime(2022, 11, 21, 17, 30))
+        self.assertEqual(fitz_from(dt), expected_result)
+
+    def test_daylight_savings_time(self):
+        # Finnish daylight savings time is UTC+03:00
+        # 21.06.2022, 15:30 UTC
+        dt = pytz.UTC.localize(datetime.datetime(2022, 6, 21, 15, 30))
+        # 21.06.2022, 18:30 Finnish TZ
+        expected_result = fitz.localize(datetime.datetime(2022, 6, 21, 18, 30))
+        self.assertEqual(fitz_from(dt), expected_result)
+
+    def test_daylight_savings_time_period_before_dst_was_used(self):
+        # DST continuous usage in Finland started in 1981
+        # Finnish daylight savings time is UTC+03:00
+        # 21.06.2022, 15:30 UTC
+        dt = pytz.UTC.localize(datetime.datetime(1970, 6, 21, 15, 30))
+        # 21.06.2022, 17:30 Finnish TZ
+        expected_result = fitz.localize(datetime.datetime(1970, 6, 21, 17, 30))
+        self.assertEqual(fitz_from(dt), expected_result)
+
+    def test_non_utc_tz(self):
+        # 21.11.2022, 15:30 UTC
+        utc_dt = pytz.UTC.localize(datetime.datetime(2022, 11, 21, 15, 30))
+        # Convert to Eastern Standard Time
+        est_tz = pytz.timezone('US/Eastern')
+        # 21.11.2022, 10:30 EST
+        est_dt = utc_dt.astimezone(est_tz)
+        # 21.11.2022, 10:30 Finnish TZ
+        expected_result = fitz.localize(datetime.datetime(2022, 11, 21, 17, 30))
+        self.assertEqual(fitz_from(est_dt), expected_result)
+
+    def test_naive_utc_time(self):
+        # 21.11.2022, 15:30 UTC
+        utc_dt = datetime.datetime(2022, 11, 21, 15, 30)
+        # 21.11.2022, 17:30 Finnish TZ
+        expected_result = fitz.localize(datetime.datetime(2022, 11, 21, 17, 30))
+        self.assertEqual(fitz_from(utc_dt), expected_result)

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -3,7 +3,7 @@ import logging
 import threading
 from datetime import datetime, timedelta, date
 from decimal import Decimal
-from typing import List, Sized, Tuple
+from typing import List, Sized, Tuple, Optional
 
 import pytz
 from django.db.models import QuerySet
@@ -228,21 +228,23 @@ def get_caller_from_stack(stack_depth: int = 1) -> inspect.FrameInfo | None:
     return None
 
 
-def utctz_from(dt: datetime) -> datetime:
+def utctz_from(dt: datetime) -> Optional[datetime]:
     """ UTC TimeZone converted datetime from given datetime. If naive datetime is given, it is assumed
         to be in utc timezone already """
-    check_tz_info_attr(dt)
+    if dt is None:
+        return None
     if dt.tzinfo is None:
         return pytz.UTC.localize(dt)
     return dt.astimezone(pytz.UTC)
 
 
-def fitz_from(dt: datetime) -> datetime:
-    """ FInnish TimeZone converted datetime from given datetime. If naive datetime is given, it is assumed
+def fitz_from(dt: datetime) -> Optional[datetime]:
+    """ Finnish TimeZone converted datetime from given datetime. If naive datetime is given, it is assumed
         to be in utc timezone """
-    check_tz_info_attr(dt)
+    if dt is None:
+        return None
     if dt.tzinfo is None:
-        pytz.UTC.localize(dt)  # first make timezone aware
+        dt = pytz.UTC.localize(dt)  # first make timezone aware
     return dt.astimezone(fitz)
 
 
@@ -252,7 +254,7 @@ def check_tz_info_attr(dt: datetime) -> None:
 
 
 def fitzstr_from(dt: datetime) -> str:
-    """ FInnish TimeZone converted string format """
+    """ Finnish TimeZone converted string format """
     return fitz_from(dt).strftime(FINNISH_DATE_FORMAT)
 
 


### PR DESCRIPTION
Now '1337'-command uses datetime from Telegram server instead of running environments local time. Moved time related utility tests to their own module, added tests for finnish time zone localization function