### PR TITLE
Add instructions on armhf docker building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update -qqy \
     chmod 755 /usr/local/bin/geckodriver
 
 COPY requirements.txt requirements.txt
-RUN pip3 install --no-cache-dir Adafruit-DHT==1.4.0 --install-option '--force-pi'
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir Adafruit-DHT==1.4.0 --install-option '--force-pi' &&\
+pip3 install --no-cache-dir -r requirements.txt
 
 # take only needed modules and starting script to the final image
 COPY bobweb bobweb

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,8 @@ WORKDIR /
 #=========
 RUN apt-get update -qqy \
     && apt-get -y install --no-install-recommends \
-    libgeos-dev=3.9.0-1 ffmpeg=7:5.1.3-1 ; \
-    echo "deb http://deb.debian.org/debian/ sid main" >> /etc/apt/sources.list \
-    && apt-get update -qqy \
-    && apt-get -y install --no-install-recommends \
-    libavcodec-extra=7:4.3.5-0+deb11u1 \
-    && wget --progress=dot:giga https://snapshot.debian.org/archive/debian/20221231T090612Z/pool/main/f/firefox/firefox_108.0-2_"$(dpkg --print-architecture)".deb -O firefox.deb \
+    libgeos-dev=3.9.0-1 ffmpeg=7:4.3.6-0+deb11u1 libavcodec-extra=7:4.3.6-0+deb11u1 ; \
+    wget --progress=dot:giga https://snapshot.debian.org/archive/debian/20221231T090612Z/pool/main/f/firefox/firefox_108.0-2_"$(dpkg --print-architecture)".deb -O firefox.deb \
     && apt-get -y install --no-install-recommends ./firefox.deb \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/* ./firefox.deb ; \
     wget --progress=dot:giga -O /tmp/geckodriver.tar.gz https://github.com/jamesmortensen/geckodriver-arm-binaries/releases/download/v0.32.0/geckodriver-v0.32.0-linux-armv7l.tar.gz ; \
@@ -27,6 +23,7 @@ RUN apt-get update -qqy \
     chmod 755 /usr/local/bin/geckodriver
 
 COPY requirements.txt requirements.txt
+RUN pip3 install --no-cache-dir Adafruit-DHT==1.4.0 --install-option '--force-pi'
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # take only needed modules and starting script to the final image

--- a/README.md
+++ b/README.md
@@ -185,6 +185,17 @@ python bobweb/web/manage.py migrate
 # ja uudelleenluominen aiheuttaa kyseisen taulun sisällön katoamisen
 ```
 
+### Muutoksia riippuvuuksiin
+
+Jos teit muutoksia esimerkiksi Dockerfile-tiedostoon, voit vielä varmistaa
+muutostesi toimivuuden paikallisesti allaolevalla komennolla. Tietokoneesi
+arkkitehtuuri (x86_64) poikkeaa Raspberry Pi:n arkkitehtuurista (armv7l)
+mikä vaikuttaa riippuvuuksien asentamiseen.
+
+```sh
+docker build --platform linux/armhf . -t bob-armhf --progress=plain --no-cache
+```
+
 ### Uuden komennon luominen
 
 Luo uusi moduuli ja sinne luokka joka perii ChatCommand luokan. Esim moduuli (tiedosto) `uusi_komento_command.py` ja siellä luokka:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ requests~=2.28.2
 selenium~=4.7.2
 shapely~=2.0.0
 XlsxWriter~=3.0.7
-Adafruit-DHT==1.4.0; platform_machine == 'armv7l'
-RPi.GPIO==0.7.1; platform_machine == 'armv7l'
+RPi.GPIO==0.7.1
 
 pydub~=0.25.1


### PR DESCRIPTION
It's possible to docker build something for armhf on x86_64 machine:

```sh
docker build --platform linux/armhf . -t bob-armhf --progress=plain --no-cache
```

Might help for debugging and possibly future CI/CD.