### PR TITLE
Added persisting docker-compose command output to a log-file.

### DIFF
--- a/deploy-simple.sh
+++ b/deploy-simple.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Starting deployment"
-docker-compose -f dev.docker-compose.yml up --build --detach --force-recreate --remove-orphans
+docker-compose -f dev.docker-compose.yml up --build --detach --force-recreate --remove-orphans |& tee docker-compose.log

--- a/deploy.bat
+++ b/deploy.bat
@@ -1,2 +1,2 @@
 echo "Starting deployment"
-docker-compose -f dev.docker-compose.yml up --build --detach --force-recreate --remove-orphans
+docker-compose -f dev.docker-compose.yml up --build --detach --force-recreate --remove-orphans > docker-compose.log

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ export COMMIT_AUTHOR_EMAIL
 
 CPU_architecture=$(uname -m)
 if [[ $CPU_architecture == 'armv7l' ]]; then
-  docker-compose -f docker-compose.yml up --build --detach --force-recreate --remove-orphans
+  docker-compose -f docker-compose.yml up --build --detach --force-recreate --remove-orphans |& tee docker-compose.log
 else
-  docker-compose -f ci.docker-compose.yml up --build --detach --force-recreate --remove-orphans
+  docker-compose -f ci.docker-compose.yml up --build --detach --force-recreate --remove-orphans |& tee docker-compose.log
 fi


### PR DESCRIPTION
- .sh scripts use linux 'tee' command to write both to the standard output and a log file. For .bat script only log file is written