### PR TITLE
Fix armhf check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ RUN apt-get update -qqy \
     chmod 755 /usr/local/bin/geckodriver
 
 COPY requirements.txt requirements.txt
-RUN pip3 install --no-cache-dir Adafruit-DHT==1.4.0 --install-option '--force-pi' &&\
-pip3 install --no-cache-dir -r requirements.txt
+
+RUN if [ "$(uname -m)" = armv7l ]; then \
+    pip3 install --no-cache-dir Adafruit-DHT==1.4.0 --install-option '--force-pi'; fi &&\
+    pip3 install --no-cache-dir -r requirements.txt
 
 # take only needed modules and starting script to the final image
 COPY bobweb bobweb

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ python bobweb/web/manage.py migrate
 ### Muutoksia riippuvuuksiin
 
 Jos teit muutoksia esimerkiksi Dockerfile-tiedostoon, voit vielä varmistaa
-muutostesi toimivuuden paikallisesti allaolevalla komennolla. Tietokoneesi
+muutostesi toimivuuden paikallisesti alla olevalla komennolla. Tietokoneesi
 arkkitehtuuri (x86_64) poikkeaa Raspberry Pi:n arkkitehtuurista (armv7l)
 mikä vaikuttaa riippuvuuksien asentamiseen.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ requests~=2.28.2
 selenium~=4.7.2
 shapely~=2.0.0
 XlsxWriter~=3.0.7
-RPi.GPIO==0.7.1
+RPi.GPIO==0.7.1; platform_machine == 'armv7l'
 
 pydub~=0.25.1


### PR DESCRIPTION
Sonarcloud does not like to install these two. That's why I added here back the condition to only install these two packages if build is done on armv7l.