### PR TITLE
Add quick systems message option to gpt command

### DIFF
--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -40,12 +40,6 @@ class GptCommand(ChatCommand):
         # Dict - Key: chatId, value: Conversation list
         self.conversation_context = {}
 
-        self.quick_system_prompts = {
-            "1": "You are an assistant named Bob (or Robert the Bot officially). Be brief and concise in your answers.",
-            "2": "Olet suomenkielinen apuri nimeltä Bob.",
-            "3": "You are an expert code developer with teaching skills."
-        }
-
     def handle_update(self, update: Update, context: CallbackContext = None):
         """
         1. Check permission. If not, notify user
@@ -84,7 +78,7 @@ class GptCommand(ChatCommand):
         started_reply_text = 'Vastauksen generointi aloitettu. Tämä vie 30-60 sekuntia.'
         started_reply = update.effective_chat.send_message(started_reply_text)
         self.add_context(update.effective_chat.id, "user", new_prompt)
-        system_prompt = self.quick_system_prompts.get(system_prompt_id, None)
+        system_prompt = quick_system_prompts.get(system_prompt_id, None)
         self.handle_response_generation_and_reply(update, system_prompt)
 
         # Delete notification message from the chat
@@ -142,15 +136,21 @@ class GptCommand(ChatCommand):
         else:
             self.gpt_command(update, sub_command_parameter, context, system_prompt_id=sub_command)
 
+quick_system_prompts = {
+    "1": "You are an assistant named Bob (or Robert the Bot officially). Be brief and concise in your answers.",
+    "2": "Olet suomenkielinen apuri nimeltä Bob.",
+    "3": "You are an expert code developer with teaching skills."
+}
 
-no_parameters_given_notification_msg = "Anna jokin syöte komennon" \
-    " jälkeen. '[.!/]gpt {syöte}'. Voit valita jonkin kolmesta" \
-    " valmiista ohjeistusviestistä laittamalla numeron 1-3" \
-    " ennen syötettä. 1: You are an assistant named Bob (or" \
-    " Robert the Bot officially)." \
-    " Be brief and concise in your answers." \
-    " 2: Olet suomenkielinen apuri nimeltä Bob." \
-    " 3: You are an expert code developer with teaching skills."
+no_parameters_given_notification_msg = f"""
+    Anna jokin syöte komennon
+    jälkeen. [.!/]gpt (syöte). Voit valita jonkin kolmesta
+    valmiista ohjeistusviestistä laittamalla numeron 1-3
+    ennen syötettä.
+    1: {quick_system_prompts["1"]}
+    2: {quick_system_prompts["2"]}
+    3: {quick_system_prompts["3"]}
+"""
 
 
 def handle_system_prompt_sub_command(update: Update, command_parameter):

--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -146,9 +146,9 @@ no_parameters_given_notification_msg = f"""
     Anna jokin syöte komennon
     jälkeen. [.!/]gpt (syöte). Voit valita jonkin kolmesta
     valmiista ohjeistusviestistä laittamalla numeron 1-3
-    ennen syötettä.
-    1: {quick_system_prompts["1"]}
-    2: {quick_system_prompts["2"]}
+    ennen syötettä.\n
+    1: {quick_system_prompts["1"]}\n
+    2: {quick_system_prompts["2"]}\n
     3: {quick_system_prompts["3"]}
 """
 

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from django.test import TestCase
 from unittest import mock
 
-from bobweb.bob import database, command_gpt, openai_api_utils
+from bobweb.bob import main, database, command_gpt, openai_api_utils
 from bobweb.bob.tests_mocks_v2 import init_chat_user, MockChat, MockUser
 
 from bobweb.bob.command_gpt import GptCommand, no_parameters_given_notification_msg

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -256,6 +256,34 @@ class ChatGptCommandTests(TestCase):
         self.assertEqual('AAA', Chat.objects.get(id=chat_a.id).gpt_system_prompt)
         self.assertEqual('🅱️', Chat.objects.get(id=b_chat.id).gpt_system_prompt)
 
+    def test_quick_system_prompt(self):
+        openai_api_utils.state.reset_cost_so_far()
+        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+        user.send_message('/gpt /1 Who won the world series in 2020?')
+        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
+                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
+        self.assertEqual(expected_reply, chat.last_bot_txt())
+
+    def test_quick_system_prompt(self):
+        openai_api_utils.state.reset_cost_so_far()
+        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+        user.send_message('/gpt /2 Who won the world series in 2020?')
+        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
+                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
+        self.assertEqual(expected_reply, chat.last_bot_txt())
+
+    def test_quick_system_prompt_that_does_not_exist(self):
+        openai_api_utils.state.reset_cost_so_far()
+        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+        user.send_message('/gpt /4 Who won the world series in 2020?')
+        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
+                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
+        self.assertEqual(expected_reply, chat.last_bot_txt())
+
+    def test_empty_prompt_after_quick_system_prompt(self):
+        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+        user.send_message('/gpt /1')
+        self.assertEqual(no_parameters_given_notification_msg, chat.last_bot_txt())
 
 def init_chat_with_bot_cc_holder_and_another_user() -> Tuple[MockChat, MockUser, MockUser]:
     """

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -7,7 +7,7 @@ from unittest import mock
 from bobweb.bob import main, database, command_gpt, openai_api_utils
 from bobweb.bob.tests_mocks_v2 import init_chat_user, MockChat, MockUser
 
-from bobweb.bob.command_gpt import GptCommand, no_parameters_given_notification_msg
+from bobweb.bob.command_gpt import GptCommand, quick_system_prompts, no_parameters_given_notification_msg
 
 import django
 
@@ -257,28 +257,35 @@ class ChatGptCommandTests(TestCase):
         self.assertEqual('🅱️', Chat.objects.get(id=b_chat.id).gpt_system_prompt)
 
     def test_quick_system_prompt(self):
-        openai_api_utils.state.reset_cost_so_far()
-        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
-        user.send_message('/gpt /1 Who won the world series in 2020?')
-        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
-                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
-        self.assertEqual(expected_reply, chat.last_bot_txt())
+        mock_method = mock.MagicMock()
+        mock_method.return_value = MockOpenAIObject()
+        with mock.patch('openai.ChatCompletion.create', mock_method):
+            chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+            user.send_message('/gpt /1 Who won the world series in 2020?')
 
-    def test_quick_system_prompt(self):
-        openai_api_utils.state.reset_cost_so_far()
-        chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
-        user.send_message('/gpt /2 Who won the world series in 2020?')
-        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
-                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
-        self.assertEqual(expected_reply, chat.last_bot_txt())
+            expected_system_msg = quick_system_prompts.get('1')
+            expected_call_args = [{'role': 'system', 'content': expected_system_msg},
+                                  {'role': 'user', 'content': 'Who won the world series in 2020?'}]
+            mock_method.assert_called_with(model='gpt-4', messages=expected_call_args)
 
-    def test_quick_system_prompt_that_does_not_exist(self):
-        openai_api_utils.state.reset_cost_so_far()
+    def test_another_quick_system_prompt(self):
+        mock_method = mock.MagicMock()
+        mock_method.return_value = MockOpenAIObject()
+        with mock.patch('openai.ChatCompletion.create', mock_method):
+            chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
+            user.send_message('/gpt /2 Who won the world series in 2020?')
+
+            expected_system_msg = quick_system_prompts.get('2')
+            expected_call_args = [{'role': 'system', 'content': expected_system_msg},
+                                  {'role': 'user', 'content': 'Who won the world series in 2020?'}]
+            mock_method.assert_called_with(model='gpt-4', messages=expected_call_args)
+
+    def test_missing_system_prompt(self):
         chat, _, user = init_chat_with_bot_cc_holder_and_another_user()
         user.send_message('/gpt /4 Who won the world series in 2020?')
-        expected_reply = 'The Los Angeles Dodgers won the World Series in 2020.' \
-                         '\n\nRahaa paloi: $0.001260, rahaa palanut rebootin jälkeen: $0.001260'
-        self.assertEqual(expected_reply, chat.last_bot_txt())
+        expected_context_content = [{'role': 'user', 'content': '/4 Who won the world series in 2020?'},
+                                    {'role': 'assistant', 'content': 'The Los Angeles Dodgers won the World Series in 2020.'}]
+        self.assertEqual(expected_context_content, gpt_command.build_message(chat.id))
 
     def test_empty_prompt_after_quick_system_prompt(self):
         chat, _, user = init_chat_with_bot_cc_holder_and_another_user()


### PR DESCRIPTION
Sometimes you want to use different system messages quickly. With this PR we add an option to use one of ready-made system prompts (1, 2 or 3) when using gpt.

E.g.

```
/gpt /2 Can I have an answer in Finnish?
```

Prompts without quick message use the old per-channel saved system message as previously.

If this is good, we could add next options to customize the "save slots" for the three quick system prompts.