### PR TITLE
epic games announcement improvements

### DIFF
--- a/bobweb/bob/broadcaster.py
+++ b/bobweb/bob/broadcaster.py
@@ -1,28 +1,43 @@
 import logging
+from typing import List
 
 import telegram
 from telegram import Bot
+from telegram.constants import ParseMode
 
 from bobweb.bob import database
-
+from bobweb.web.bobapp.models import Chat
 
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)  #NOSONAR
 logger = logging.getLogger(__name__)
 
 
 async def broadcast(bot: Bot, text: str):
+    """ Broadcasts fo all chats known to bot that have broadcast enabled """
+    chats = [chat for chat in database.get_chats() if chat.broadcast_enabled]
+    await broadcast_to_chats(bot, chats, text)
+
+
+async def broadcast_to_chats(bot: Bot,
+                             chats: List[Chat],
+                             text: str,
+                             image_bytes: bytes = None,
+                             parse_mode: ParseMode = None):
+    """ Broadcasts given message to all given chats. Sends image if given as parameter """
     if text is not None and text != "":
-        chats = database.get_chats()
         for chat in chats:
-            if chat.broadcast_enabled:
-                try:
-                    await bot.send_message(chat_id=chat.id, text=text)
-                except telegram.error.BadRequest as e:
-                    logger.error("Tried to broadcast to chat with id " + str(chat.id) +
-                                 " but Telegram-API responded with \"BadRequest: " + str(e) + "\"")
-                except telegram.error.Forbidden as e2:
-                    logger.error("Tried to broadcast to chat with id " + str(chat.id) +
-                                 " but Telegram-API responded with \"BadRequest: " + str(e2) + "\""
-                                 "User has propably blocked bot so broadcast is disabled in the chat.")
-                    chat.broadcast_enabled = False
-                    chat.save()
+            try:
+                if image_bytes is not None:
+                    await bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=text, parse_mode=parse_mode)
+                else:
+                    await bot.send_message(chat_id=chat.id, text=text, parse_mode=parse_mode)
+            except telegram.error.BadRequest as e:
+                logger.error("Tried to broadcast to chat with id " + str(chat.id) +
+                             " but Telegram-API responded with \"BadRequest: " + str(e) + "\"")
+            except telegram.error.Forbidden as e2:
+                logger.error("Tried to broadcast to chat with id " + str(chat.id) +
+                             " but Telegram-API responded with \"BadRequest: " + str(e2) + "\""
+                             "User has propably blocked bot so broadcast is disabled in the chat.")
+                chat.broadcast_enabled = False
+                chat.save()
+

--- a/bobweb/bob/command_epic_games.py
+++ b/bobweb/bob/command_epic_games.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import logging
 from datetime import datetime
@@ -10,7 +11,8 @@ from telegram import Update
 from telegram.constants import ParseMode
 from telegram.ext import CallbackContext
 
-from bobweb.bob import async_http
+from bobweb.bob import async_http, database
+from bobweb.bob.broadcaster import broadcast_to_chats
 from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob.command_image_generation import image_to_byte_array
 from bobweb.bob.utils_common import fitzstr_from, has, flatten, dict_search
@@ -29,7 +31,7 @@ class EpicGamesOffersCommand(ChatCommand):
 
     async def handle_update(self, update: Update, context: CallbackContext = None) -> None:
         try:
-            msg, image_bytes = await create_free_games_announcement_msg()
+            msg, image_bytes = await find_current_free_game_offers_and_create_message()
             if has(image_bytes):
                 await update.effective_message.reply_photo(photo=image_bytes, caption=msg, parse_mode=ParseMode.HTML, quote=False)
             else:
@@ -41,7 +43,7 @@ class EpicGamesOffersCommand(ChatCommand):
 
 
 fetch_failed_msg = 'Ilmaisten eeppisten pelien haku epäonnistui 🔌✂️'
-fetch_ok_no_free_games = 'Ilmaisia eeppisiä pelejä ei ole tällä hetkellä tarjolla 👾'
+fetch_ok_no_free_games = 'Uusia ilmaisia eeppisiä pelejä ei ole tällä hetkellä tarjolla 👾'
 epic_free_games_api_endpoint = 'https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?country=FI'
 epic_games_store_product_base_url = 'https://store.epicgames.com/en-US/p/'
 epic_games_store_free_games_page_url = 'https://store.epicgames.com/en-US/free-games'
@@ -56,25 +58,95 @@ class EpicGamesOffer:
                  page_slug: str,
                  image_tall_url: str,
                  image_thumbnail_url: str):
-        self.title = title
-        self.description = description
-        self.starts_at = starts_at
-        self.ends_at = ends_at
-        self.page_slug = page_slug
-        self.vertical_img_url = image_tall_url
-        self.horizontal_img_url = image_thumbnail_url
+        self.title: str = title
+        self.description: str = description
+        self.starts_at: datetime = starts_at
+        self.ends_at: datetime = ends_at
+        self.page_slug: str = page_slug
+        self.vertical_img_url: str = image_tall_url
+        self.horizontal_img_url: str = image_thumbnail_url
 
 
-async def create_free_games_announcement_msg() -> tuple[str, bytes | None]:
-    games = await fetch_free_epic_games_offering()
+class NoNewFreeGamesError(Exception):
+    """ Simple error class for situation where new games are expected and no new games are found """
+    pass
+
+
+async def daily_announce_new_free_epic_games_store_games(context: CallbackContext):
+    """ Tries to find and announce all new game offers starting on current date for 5 minutes. Request offers from Epic
+        Games Api once a minute. If no new games are found after 5 minutes no announcement is made. If all requests fail
+        and no successful response is gotten, announces failure after 5 minutes is up. Returns immediately after
+        successful delivery. This is done to ensure that the bot announces new game offers as soon as possible. """
+    chats_with_announcement_on = [x for x in database.get_chats() if x.free_game_offers_enabled]
+    if len(chats_with_announcement_on) == 0:
+        return  # Early return if no chats with setting turned on
+
+    max_try_count = 5
+    try_count = 0
+    delay_seconds = 60
+
+    # Possible status'
+    client_response_error = None
+    response_ok_no_new_games = False
+
+    while try_count < max_try_count:
+        # Define either announcement message and possible game images or fetch_failed_msg without image
+        try_count += 1
+        try:
+            msg, image_bytes = await find_new_free_game_offers_and_create_message()
+            await broadcast_to_chats(context.bot, chats_with_announcement_on, msg, image_bytes)
+            return  # Early return after successful announcement
+        except ClientResponseError as e:
+            # Set client_response_error. If no successful request is done with time period,
+            # connection error message is sent
+            client_response_error = e
+        except NoNewFreeGamesError:
+            # If no new games are found. As this means successful request with response,
+            # client_response_error is overriden
+            client_response_error = None
+            response_ok_no_new_games = True
+        finally:
+            if try_count < max_try_count:
+                await asyncio.sleep(delay_seconds)
+
+    if client_response_error is not None:
+        log_msg = (f'Epic Games Api error. [status]: {str(client_response_error.status)}, [message]: '
+                   f'{client_response_error.message}, [headers]: {client_response_error.headers}')
+        logger.exception(log_msg, exc_info=True)
+        await broadcast_to_chats(context.bot, chats_with_announcement_on, fetch_failed_msg)
+
+    elif response_ok_no_new_games:
+        logger.info('Epic games offers status fetched successfully but no new free games found')
+        is_thursday = datetime.today().weekday() == 3  # Monday == 0 ... Sunday == 6
+        if is_thursday:
+            # Only if it's thursday, should there be announcement that no games were found.
+            # On other week days it is the expected outcome
+            await broadcast_to_chats(context.bot, chats_with_announcement_on, fetch_ok_no_free_games)
+
+
+async def find_new_free_game_offers_and_create_message() -> tuple[str, bytes | None]:
+    """ Finds all new free game offers starting today. If none is found, or fetch fails, raises an exception """
+    games: list[EpicGamesOffer] = await fetch_free_epic_games_offering(only_offers_starting_today=True)
+    if len(games) == 0:
+        raise NoNewFreeGamesError()
+
+    return await create_message_and_game_image_compilation(games, '📬 Uudet ilmaiset eeppiset pelit 📩')
+
+
+async def find_current_free_game_offers_and_create_message() -> tuple[str, bytes | None]:
+    """ Creates message with current free game offers """
+    games: list[EpicGamesOffer] = await fetch_free_epic_games_offering()
     if len(games) == 0:
         return fetch_ok_no_free_games, None
-    else:
-        heading = '📬 Viikon ilmaiset eeppiset pelit 📩'
-        msg = heading + format_games_offer_list(games)
-        msg_image = await get_game_offers_image(games)
-        image_bytes = image_to_byte_array(msg_image)
-        return msg, image_bytes
+
+    return await create_message_and_game_image_compilation(games, '📬 Ilmaiset eeppiset pelit 📩')
+
+
+async def create_message_and_game_image_compilation(games: List[EpicGamesOffer], heading: str) -> Tuple[str, bytes]:
+    msg = heading + format_games_offer_list(games)
+    msg_image = await get_game_offers_image(games)
+    image_bytes = image_to_byte_array(msg_image)
+    return msg, image_bytes
 
 
 def format_games_offer_list(games: list[EpicGamesOffer]):
@@ -88,7 +160,8 @@ def format_games_offer_list(games: list[EpicGamesOffer]):
     return game_list
 
 
-async def fetch_free_epic_games_offering() -> list[EpicGamesOffer]:
+async def fetch_free_epic_games_offering(only_offers_starting_today: bool = False) -> list[EpicGamesOffer]:
+    today: datetime.date = datetime.today().date()
     content: dict = await async_http.fetch_json(epic_free_games_api_endpoint)
     # use None-safe dict-get-chain that returns list if any key is not found
     game_dict_list = dict_search(content, 'data', 'Catalog', 'searchStore', 'elements') or []
@@ -96,7 +169,10 @@ async def fetch_free_epic_games_offering() -> list[EpicGamesOffer]:
     game_offers = []
     for d in game_dict_list:
         game_offer: EpicGamesOffer = extract_free_game_offer_from_game_dict(d)
-        if game_offer is not None:
+        # is added to the list if:
+        # - has promotion
+        # - only_offers_starting_today is false or if it is set to be true and promotion starts on current day
+        if game_offer is not None and (only_offers_starting_today is False or game_offer.starts_at.date() == today):
             game_offers.append(game_offer)
 
     return game_offers

--- a/bobweb/bob/scheduler.py
+++ b/bobweb/bob/scheduler.py
@@ -1,19 +1,16 @@
 import datetime
 import logging
 
-from aiohttp import ClientResponseError
-from telegram.constants import ParseMode
 from telegram.ext import Application, CallbackContext
 import signal  # Keyboard interrupt listening for Windows
 
-from bobweb.bob.command_epic_games import create_free_games_announcement_msg, fetch_failed_msg
+from bobweb.bob.command_epic_games import daily_announce_new_free_epic_games_store_games
 from bobweb.bob.git_promotions import broadcast_and_promote
 from bobweb.bob.resources.bob_constants import fitz
-from bobweb.bob.utils_common import has
 
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-from bobweb.bob import database, broadcaster, nordpool_service
+from bobweb.bob import broadcaster, nordpool_service
 from bobweb.bob import db_backup
 
 logger = logging.getLogger(__name__)
@@ -39,7 +36,9 @@ class Scheduler:
     Class for all scheduled task and background services.
 
     Since update 13.0 -> 20.5 all scheduled tasks are handled with PTB library's JobQueue
-    Documentation: https://docs.python-telegram-bot.org/en/v20.5/telegram.ext.jobqueue.html
+    JobQueue documentation: https://docs.python-telegram-bot.org/en/v20.5/telegram.ext.jobqueue.html
+
+    Cron syntax codumentation: https://apscheduler.readthedocs.io/en/stable/modules/triggers/cron.html
 
     Example:
     “Every day at 08:00.”
@@ -54,12 +53,13 @@ class Scheduler:
         # First invoke all jobs that should be run at startup and then add recurrent tasks
         # At the startup do broadcast and promote action immediately once
         application.job_queue.run_once(broadcast_and_promote, 0)
+        application.job_queue.run_once(daily_announce_new_free_epic_games_store_games, 5)
 
-        # 'At 18:05 on Thursday.'
-        application.job_queue.run_daily(days=THURSDAY, time=datetime.time(hour=18, minute=5, tzinfo=fitz),
-                                        callback=announce_free_epic_games_store_games)
+        # Is started Every day at 18:00:30
+        application.job_queue.run_daily(days=EVERY_WEEK_DAY, time=datetime.time(hour=18, minute=0, second=30, tzinfo=fitz),
+                                        callback=daily_announce_new_free_epic_games_store_games)
 
-        # “At 17:00 on Friday.”
+        # At 17:00 on Friday
         application.job_queue.run_daily(days=FRIDAY, time=datetime.time(hour=17, minute=0, tzinfo=fitz),
                                         callback=friday_noon)
 
@@ -72,23 +72,3 @@ class Scheduler:
 async def friday_noon(context: CallbackContext):
     await db_backup.create(context.bot)
     await broadcaster.broadcast(context.bot, "Jahas, työviikko taas pulkassa,,,")
-
-
-async def announce_free_epic_games_store_games(context: CallbackContext):
-    chats_with_announcement_on = [x for x in database.get_chats() if x.free_game_offers_enabled]
-    if len(chats_with_announcement_on) == 0:
-        return  # Early return if no chats with
-
-    # Define either announcement message and possible game images or fetch_failed_msg without image
-    try:
-        msg, image_bytes = await create_free_games_announcement_msg()
-    except ClientResponseError as e:
-        log_msg = f'Epic Games Api error. [status]: {str(e.status)}, [message]: {e.message}, [headers]: {e.headers}'
-        logger.exception(log_msg, exc_info=True)
-        msg, image_bytes = fetch_failed_msg, None
-
-    for chat in chats_with_announcement_on:
-        if has(image_bytes):
-            await context.bot.send_photo(chat_id=chat.id, photo=image_bytes, caption=msg, parse_mode=ParseMode.HTML)
-        else:
-            await context.bot.send_message(chat_id=chat.id, text=msg, parse_mode=ParseMode.HTML)

--- a/bobweb/bob/test_command_epic_games.py
+++ b/bobweb/bob/test_command_epic_games.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import json
 from typing import List
@@ -6,28 +7,32 @@ from unittest import mock
 
 import django
 import pytest
+from aiohttp import ClientResponseError
 from django.core import management
 from django.test import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import requests
 from PIL.Image import Image
+from freezegun import freeze_time
 from requests import Response
+from telegram.ext import CallbackContext
 
-from bobweb.bob import command_epic_games
+from bobweb.bob import command_epic_games, database
 from bobweb.bob.command_epic_games import epic_free_games_api_endpoint, EpicGamesOffersCommand, \
-    get_product_page_or_deals_page_url
+    get_product_page_or_deals_page_url, daily_announce_new_free_epic_games_store_games
 from bobweb.bob.test_command_kunta import create_mock_image
 from bobweb.bob.tests_mocks_v2 import init_chat_user
-from bobweb.bob.tests_utils import assert_command_triggers, mock_request_raises_client_response_error, mock_fetch_json_with_content
+from bobweb.bob.tests_utils import assert_command_triggers, mock_request_raises_client_response_error, \
+    mock_fetch_json_with_content, AsyncMock
 
 
-async def mock_fetch_json(urls: str, *args, **kwargs):
-    if 'freeGamesPromotions' in urls:
+async def mock_fetch_json(url: str, *args, **kwargs):
+    if 'freeGamesPromotions' in url:
         # first api call that gets the promotion date
         with open('bobweb/bob/resources/test/epicGamesFreeGamesPromotionsExample.json') as example_json:
             return json.loads(example_json.read())
-    elif urls.endswith('.png'):
+    elif url.endswith('.png'):
         # Game offer image request -> Create a mock response with appropriate content
         img: Image = create_mock_image(*args, **kwargs)
         img_byte_array = io.BytesIO()
@@ -39,8 +44,25 @@ async def mock_fetch_all_content_bytes(urls: List[str], *args, **kwargs):
     return [await mock_fetch_json(url) for url in urls]
 
 
+async def mock_fetch_raises_client_response_error(*args, **kwargs):
+    raise ClientResponseError(status=-1, message='-1', headers={'a': 1}, request_info=None, history=None)
+
+
+class MockApi:
+    """ Mock api that only returns requested response at third call """
+    call_count = 0
+
+    async def mock_fetch_succeed_on_third_call(*args, **kwargs):
+        MockApi.call_count += 1
+        if MockApi.call_count >= 3:
+            return await mock_fetch_json(*args, **kwargs)
+        else:
+            return await mock_fetch_raises_client_response_error(*args, **kwargs)
+
+
 class EpicGamesApiEndpointPingTest(TestCase):
     """ Smoke test against the real api """
+
     async def test_epic_games_api_endpoint_ok(self):
         res: Response = requests.get(epic_free_games_api_endpoint)  # Synchronous requests-library call is OK here
         self.assertEqual(200, res.status_code)
@@ -86,3 +108,84 @@ class EpicGamesBehavioralTests(django.test.TransactionTestCase):
         expected = 'https://store.epicgames.com/en-US/free-games'
         actual = get_product_page_or_deals_page_url(None)
         self.assertEqual(expected, actual)
+
+
+@pytest.mark.asyncio
+@mock.patch('asyncio.sleep', new_callable=AsyncMock)
+@mock.patch('bobweb.bob.async_http.fetch_json', mock_fetch_json)
+@mock.patch('bobweb.bob.async_http.fetch_all_content_bytes', mock_fetch_all_content_bytes)
+class EpicGamesDailyAnnounceTests(django.test.TransactionTestCase):
+    chat = None
+    cb = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(EpicGamesDailyAnnounceTests, cls).setUpClass()
+        management.call_command('migrate')
+
+    def setUp(self):
+        chat, user = init_chat_user()
+        asyncio.run(user.send_message('hi'))
+        chat_in_db = database.get_chat(chat.id)
+        chat_in_db.free_game_offers_enabled = True
+        chat_in_db.save()
+
+        cb: CallbackContext = Mock(spec=CallbackContext)
+        cb.bot = chat.bot
+
+        self.chat = chat
+        self.cb = cb
+
+    @freeze_time('2023-01-01')
+    async def test_no_new_offers_not_thursday(self, _):
+        with self.assertLogs(level='INFO') as log:
+            await daily_announce_new_free_epic_games_store_games(self.cb)
+            self.assertIn('status fetched successfully but no new free games found', log.output[-1])
+
+            # No messages as it's not thursday
+            self.assertEqual([], self.chat.bot.messages)
+
+    @freeze_time('2023-01-05')
+    async def test_no_new_offers_its_thursday(self, _):
+        with self.assertLogs(level='INFO') as log:
+            await daily_announce_new_free_epic_games_store_games(self.cb)
+            self.assertIn('status fetched successfully but no new free games found', log.output[-1])
+
+            # Should have message, as it is expected to have new offers on thursday
+            self.assertEqual('Uusia ilmaisia eeppisiä pelejä ei ole tällä hetkellä tarjolla 👾', self.chat.last_bot_txt())
+
+    @freeze_time('2023-01-01')
+    async def test_api_get_request_is_called_repeatedly_if_it_fails(self, sleep_mock):
+        asyncio_fetch_mock = AsyncMock()
+        asyncio_fetch_mock.return_value = await mock_fetch_json('freeGamesPromotions')
+        with mock.patch('bobweb.bob.async_http.fetch_json', asyncio_fetch_mock) as fetch_mock:
+            await daily_announce_new_free_epic_games_store_games(self.cb)
+            # Fetch is expected to be called 5 times as
+            self.assertEqual(5, fetch_mock.call_count)
+            # And sleep should have been called 4 times with parameter of 60 seconds
+            self.assertEqual(4, sleep_mock.call_count)
+            self.assertEqual(60, sleep_mock.mock_calls[-1].args[-1])
+
+    async def test_client_response_error(self, _):
+        with (
+            self.assertLogs(level='ERROR') as log,
+            mock.patch('bobweb.bob.async_http.fetch_json', mock_fetch_raises_client_response_error)
+        ):
+            await daily_announce_new_free_epic_games_store_games(self.cb)
+            # Should log an error to log and give user-friendly notification that fetch has failed
+            self.assertIn('Epic Games Api error. [status]: -1, [message]: -1, [headers]: {\'a\': 1}', log.output[-1])
+            self.assertEqual('Ilmaisten eeppisten pelien haku epäonnistui 🔌✂️', self.chat.last_bot_txt())
+
+
+    @freeze_time('2023-01-19')  # Date on which there is a starting free game promotion in the test data
+    async def test_fetch_succeeds_on_third_try(self, _):
+        mock_api = MockApi
+        with (
+            mock.patch('bobweb.bob.async_http.fetch_json', mock_api.mock_fetch_succeed_on_third_call),
+            self.assertNoLogs(logger=command_epic_games.logger)  # And there are no messages logged
+        ):
+            await daily_announce_new_free_epic_games_store_games(self.cb)
+            # Check that expected game name is in response
+            self.assertIn('Epistory - Typing Chronicles', self.chat.last_bot_txt())
+            # Mock api has been called only three times, as the third time succeeds
+            self.assertEqual(3, mock_api.call_count)

--- a/bobweb/bob/test_command_epic_games.py
+++ b/bobweb/bob/test_command_epic_games.py
@@ -92,7 +92,7 @@ class EpicGamesBehavioralTests(django.test.TransactionTestCase):
         with mock.patch('bobweb.bob.async_http.fetch_json', mock_request_raises_client_response_error(404)):
             chat, user = init_chat_user()
             await user.send_message('/epicgames')
-            self.assertIn(command_epic_games.fetch_failed_msg, chat.last_bot_txt())
+            self.assertIn(command_epic_games.fetch_failed_no_connection_msg, chat.last_bot_txt())
 
     async def test_should_inform_if_response_ok_but_no_free_games(self):
         with mock.patch('bobweb.bob.async_http.fetch_json', mock_fetch_json_with_content({})):
@@ -174,8 +174,7 @@ class EpicGamesDailyAnnounceTests(django.test.TransactionTestCase):
             await daily_announce_new_free_epic_games_store_games(self.cb)
             # Should log an error to log and give user-friendly notification that fetch has failed
             self.assertIn('Epic Games Api error. [status]: -1, [message]: -1, [headers]: {\'a\': 1}', log.output[-1])
-            self.assertEqual('Ilmaisten eeppisten pelien haku epäonnistui 🔌✂️', self.chat.last_bot_txt())
-
+            self.assertIn('ei onnistuttu muodostamaan yhteyttä', self.chat.last_bot_txt())
 
     @freeze_time('2023-01-19')  # Date on which there is a starting free game promotion in the test data
     async def test_fetch_succeeds_on_third_try(self, _):


### PR DESCRIPTION
- split `broadcast` method to two. One that broadcasts to all chats with broadcasting set on and one that broadcasts to all given chats
- changed epic games scheduled free games announcement check to be run on every day
  - scheduled job now checks for new free games startiung from 18:00:30. New games are checked once a minute for 5 tries. For each promotion checks that if it's starting date is current date, it is broadcasted as new free game promotion even though it is not thursday. If no new free games are found on thursday when new promotions are expected, broadcasts no-games-message after 5 tries