### PR TITLE
Small fixes to Epic Games data handling, '/sahko'-command error messages and to image media contained message handling

### DIFF
--- a/bobweb/bob/message_handler.py
+++ b/bobweb/bob/message_handler.py
@@ -27,9 +27,12 @@ async def handle_update(update: Update, context: CallbackContext = None):
         await message_handler_voice.handle_voice_or_video_note_message(update)
 
     if update.effective_message.caption:
-        # Update contains image media and message text is in caption attribute.
-        # Set caption to text attribute, so that the message is handled same way as messages without image media.
-        update.effective_message.text = update.effective_message.caption
+        # If update contains media content and message text is in a caption attribute. Set caption to text attribute,
+        # so that the message is handled same way as messages without media content. However, as since PTB 20.0
+        # all PTB classes are immutable, we have to use this 'hack' of unfreezing the message-object. This is not
+        # recommended or supported by PTB, but it resolves the issue.
+        with update.effective_message._unfrozen() as unfrozen_message:
+            unfrozen_message.text = update.effective_message.caption
 
     if update.effective_message.text:
         await process_update(update, context)

--- a/bobweb/bob/test_command_epic_games.py
+++ b/bobweb/bob/test_command_epic_games.py
@@ -75,6 +75,7 @@ class EpicGamesApiEndpointPingTest(TestCase):
 
 # By default, if nothing else is defined, all request.get requests are returned with this mock
 @pytest.mark.asyncio
+@freeze_time('2023-01-20')  # Date on which there is a starting free game promotion in the test data
 @mock.patch('bobweb.bob.async_http.fetch_json', mock_fetch_json)
 @mock.patch('bobweb.bob.async_http.fetch_all_content_bytes', mock_fetch_all_content_bytes)
 class EpicGamesBehavioralTests(django.test.TransactionTestCase):
@@ -196,7 +197,7 @@ class EpicGamesDailyAnnounceTests(django.test.TransactionTestCase):
             self.assertIn('Epic Games error: error_msg', log.output[-1])
             self.assertIn('haku tai tietojen prosessointi epäonnistui', self.chat.last_bot_txt())
 
-    @freeze_time('2023-01-19')  # Date on which there is a starting free game promotion in the test data
+    @freeze_time('2023-01-19 16:05')  # Date on which there is a starting free game promotion in the test data
     async def test_fetch_succeeds_on_third_try(self, _):
         mock_api = MockApi
         with (
@@ -209,7 +210,7 @@ class EpicGamesDailyAnnounceTests(django.test.TransactionTestCase):
             # Mock api has been called only three times, as the third time succeeds
             self.assertEqual(3, mock_api.call_count)
 
-    @freeze_time('2023-01-19')  # Date on which there is a starting free game promotion in the test data
+    @freeze_time('2023-01-19 16:05')  # Date on which there is a starting free game promotion in the test data
     async def test_should_have_parse_mode_set_to_html_and_contains_html_links(self, _):
         await daily_announce_new_free_epic_games_store_games(self.cb)
         self.assertEqual(ParseMode.HTML, self.chat.last_bot_msg().parse_mode)

--- a/bobweb/bob/test_command_sahko.py
+++ b/bobweb/bob/test_command_sahko.py
@@ -35,6 +35,12 @@ class SahkoCommandFetchOrProcessError(django.test.TransactionTestCase):
         await user.send_message(sahko_command)
         self.assertIn(command_sahko.fetch_failed_msg, chat.last_bot_txt())
 
+    @mock.patch('bobweb.bob.async_http.fetch_json', mock_request_raises_client_response_error(status=503))
+    async def test_should_inform_if_fetch_failed_because_of_nordpool_api(self):
+        chat, user = init_chat_user()
+        await user.send_message(sahko_command)
+        self.assertIn(command_sahko.fetch_failed_msg_res_status_code_5xx, chat.last_bot_txt())
+
 
 @pytest.mark.asyncio
 # Define frozen time that is included in the mock data set. Mock data contains data for 10.-17.2.2023

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -275,6 +275,14 @@ def fitzstr_from(dt: datetime) -> str:
     return fitz_dt.strftime(FINNISH_DATE_FORMAT)
 
 
+def strptime_or_none(string: str, time_format: str) -> Optional[datetime]:
+    """ tries to parse given string with given format and returns None if parsing fails for any reason"""
+    try:
+        return datetime.strptime(string, time_format)
+    except (ValueError, TypeError):
+        return None
+
+
 def is_weekend(dt: datetime) -> bool:
     # Monday == 0 ... Saturday == 5, Sunday == 6
     return dt.weekday() >= 5


### PR DESCRIPTION
- fixed problem where media messages with caption were not handled since ptb library 20.0 update. Now works as before the update
- fixed epic games problem. For each promotion for the product makes null-safe search for the first promotion that has both start and end datetime defined and that is active at the moment. If product has no such promotion, it is ignored.
- Added new error message to '/sahko' -command for when nordpool api responds with 5xx status response