### PR TITLE
Add support for sending long gpt responses in multiple messages

### DIFF
--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -48,9 +48,7 @@ async def handle_message_with_dq(update: Update, context: CallbackContext):
     dq_date = update.effective_message.date  # utc
     season = database.find_active_dq_season(chat_id, dq_date)
     if has_no(season):
-        activity = CommandActivity(initial_update=update)
-        command_service.instance.add_activity(activity)
-        await activity.start_with_state(SetSeasonStartDateState())
+        await command_service.instance.start_new_activity(update, SetSeasonStartDateState())
         return  # Create season activity started and as such this daily question handling is halted
 
     # Check that update author is not same as prev dq author. If so, inform
@@ -77,9 +75,7 @@ async def handle_message_with_dq(update: Update, context: CallbackContext):
     # If there is gap in weekdays between this and last question ask user which dates question this is
     if has(prev_dq) and weekday_count_between(prev_dq.date_of_question, dq_date) > 1:
         state = ConfirmQuestionTargetDate(prev_dq=prev_dq, current_dq=saved_dq, winner_set=winner_set)
-        activity = CommandActivity(initial_update=update)
-        command_service.instance.add_activity(activity)
-        await activity.start_with_state(state)
+        await command_service.instance.start_new_activity(update, state)
         return  # ConfirmQuestionTargetDate takes care of rest
 
     if notification_text is None:
@@ -168,9 +164,7 @@ class DailyQuestionCommand(ChatCommand):
     invoke_on_edit = True  # Should be invoked on message edits
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
-        activity = CommandActivity(initial_update=update)
-        command_service.instance.add_activity(activity)
-        await activity.start_with_state(DQMainMenuState())
+        await command_service.instance.start_new_activity(update, DQMainMenuState())
 
 
 # Manages situations, where answer to daily question has not been registered or saved

--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -21,7 +21,7 @@ from bobweb.bob.openai_api_utils import notify_message_author_has_no_permission_
     ResponseGenerationException, GptModel, \
     determine_suitable_model_for_version_based_on_message_history, GptChatMessage, ContextRole
 from bobweb.bob.resources.bob_constants import PREFIXES_MATCHER
-from bobweb.bob.utils_common import object_search, send_bot_is_typing_status_update
+from bobweb.bob.utils_common import object_search, send_bot_is_typing_status_update, reply_long_text_with_markdown
 from bobweb.web.bobapp.models import Chat as ChatEntity
 
 logger = logging.getLogger(__name__)
@@ -114,8 +114,9 @@ async def gpt_command(update: Update, context: CallbackContext) -> None:
         use_quote = False
         reply = 'Jokin virhe Gpt-komennon käsittelyssä, mille ei ole jaksettu tehdä varsinaista virheiden käsittelyä.'
 
-    # All replies are as 'reply' to the prompt message to keep the message thread
-    await update.effective_message.reply_text(reply, quote=use_quote, parse_mode=ParseMode.MARKDOWN)
+    # All replies are as 'reply' to the prompt message to keep the message thread.
+    # Use wrapped reply method that sends text in multiple messages if it is too long.
+    await reply_long_text_with_markdown(update, reply, quote=use_quote)
 
     # Delete notification message from the chat
     if context is not None:

--- a/bobweb/bob/command_image_generation.py
+++ b/bobweb/bob/command_image_generation.py
@@ -16,7 +16,7 @@ from bobweb.bob import image_generating_service, openai_api_utils
 from bobweb.bob.image_generating_service import ImageGeneratingModel, ImageGenerationResponse
 from bobweb.bob.openai_api_utils import notify_message_author_has_no_permission_to_use_api, \
     ResponseGenerationException
-from bobweb.bob.resources.bob_constants import fitz, FILE_NAME_DATE_FORMAT
+from bobweb.bob.resources.bob_constants import fitz, FILE_NAME_DATE_FORMAT, TELEGRAM_MEDIA_MESSAGE_CAPTION_MAX_LENGTH
 from django.utils.text import slugify
 from telegram import Update, InputMediaPhoto
 from telegram.ext import CallbackContext
@@ -122,8 +122,7 @@ async def send_images_response(update: Update, caption: string, images: List[Ima
     than maximum caption length, first images are sent without a caption and then caption is sent as a reply
     to the images
     """
-    telegram_image_caption_maximum_length = 1024
-    if len(caption) <= telegram_image_caption_maximum_length:
+    if len(caption) <= TELEGRAM_MEDIA_MESSAGE_CAPTION_MAX_LENGTH:
         caption_included_to_media = caption
         send_caption_as_message = False
     else:

--- a/bobweb/bob/command_sahko.py
+++ b/bobweb/bob/command_sahko.py
@@ -32,9 +32,7 @@ class SahkoCommand(ChatCommand):
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
         await send_bot_is_typing_status_update(update.effective_chat)
-        activity = CommandActivity(initial_update=update)
-        command_service.instance.add_activity(activity)
-        await activity.start_with_state(SahkoBaseState())
+        await command_service.instance.start_new_activity(update, SahkoBaseState())
 
 
 # Buttons for SahkoBaseState

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -7,6 +7,7 @@ from telegram.constants import ParseMode
 from telegram.ext import CallbackContext
 
 from bobweb.bob import command_gpt
+from bobweb.bob.activities.activity_state import ActivityState
 from bobweb.bob.activities.command_activity import CommandActivity
 from bobweb.bob.command import ChatCommand
 from bobweb.bob.command_aika import AikaCommand
@@ -70,8 +71,10 @@ class CommandService:
         else:
             return False
 
-    def add_activity(self, activity: CommandActivity):
+    async def start_new_activity(self, initial_update: Update, initial_state: ActivityState):
+        activity: CommandActivity = CommandActivity(initial_update=initial_update)
         self.current_activities.append(activity)
+        await activity.start_with_state(initial_state)
 
     def remove_activity(self, activity: CommandActivity):
         self.current_activities.remove(activity)

--- a/bobweb/bob/command_settings.py
+++ b/bobweb/bob/command_settings.py
@@ -25,10 +25,8 @@ class SettingsCommand(ChatCommand):
         )
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
-        activity = CommandActivity(initial_update=update)
-        command_service.instance.add_activity(activity)
         chat = database.get_chat(update.effective_chat.id)
-        await activity.start_with_state(SettingsMenuOpenState(chat))
+        await command_service.instance.start_new_activity(update, SettingsMenuOpenState(chat))
 
 
 toggleable_property_key = '_enabled'

--- a/bobweb/bob/resources/bob_constants.py
+++ b/bobweb/bob/resources/bob_constants.py
@@ -15,3 +15,8 @@ FILE_NAME_DATE_FORMAT = '%Y-%m-%d_%H%M'  # For files. Contains no illegal charac
 DEFAULT_TIMEZONE = 'Europe/Helsinki'  # Default timezone for bot
 fitz = pytz.timezone(DEFAULT_TIMEZONE)
 utctz = pytz.UTC
+
+# Single telegram text message max content length in characters
+TELEGRAM_MESSAGE_MAX_LENGTH = 4096
+# Maximum character count for caption in message with media (photo, video etc.)
+TELEGRAM_MEDIA_MESSAGE_CAPTION_MAX_LENGTH = 1024

--- a/bobweb/bob/test_main.py
+++ b/bobweb/bob/test_main.py
@@ -405,3 +405,9 @@ class Test(django.test.TransactionTestCase):
         text = '```\nFoo Bar\n\ntest test\n```'
         expected = ['```\nFoo Bar\n```', '```\ntest test\n```']
         self.assertEqual(expected, split_text_keep_text_blocks(text, 10, 20))
+
+        # If message max length limit is inside code block, but the code block starts within the min and max
+        # length limits, splits messages just before start of the clode block
+        text = '1234567890 ```\nFoo Bar```'
+        expected = ['1234567890', '```\nFoo Bar```']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 8, 15))

--- a/bobweb/bob/test_main.py
+++ b/bobweb/bob/test_main.py
@@ -31,8 +31,7 @@ from bobweb.bob.tests_mocks_v2 import init_chat_user, MockUpdate, MockMessage, M
     init_private_chat_and_user
 from bobweb.bob.tests_utils import assert_command_triggers
 from bobweb.bob.utils_common import split_to_chunks, flatten, \
-    min_max_normalize, reply_long_text_with_markdown, split_to_chunks_keep_text_blocks, split_text_keep_text_blocks_intact, \
-    find_start_indexes, split_text_keep_text_blocks
+    min_max_normalize, find_start_indexes, split_text_keep_text_blocks
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
@@ -299,7 +298,7 @@ class Test(django.test.TransactionTestCase):
 
         iterable = ['a', 'b', 'c', 'd']
         chunk_size = -1
-        expected = ['a', 'b', 'c', 'd']
+        expected = []
         self.assertEqual(expected, split_to_chunks(iterable, chunk_size))
 
         # Tests that text can be split as well

--- a/bobweb/bob/test_main.py
+++ b/bobweb/bob/test_main.py
@@ -31,7 +31,8 @@ from bobweb.bob.tests_mocks_v2 import init_chat_user, MockUpdate, MockMessage, M
     init_private_chat_and_user
 from bobweb.bob.tests_utils import assert_command_triggers
 from bobweb.bob.utils_common import split_to_chunks, flatten, \
-    min_max_normalize
+    min_max_normalize, reply_long_text_with_markdown, split_to_chunks_keep_text_blocks, split_text_keep_text_blocks_intact, \
+    find_start_indexes, split_text_keep_text_blocks
 
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
@@ -301,6 +302,12 @@ class Test(django.test.TransactionTestCase):
         expected = ['a', 'b', 'c', 'd']
         self.assertEqual(expected, split_to_chunks(iterable, chunk_size))
 
+        # Tests that text can be split as well
+        iterable = 'abcd efg'
+        chunk_size = 3
+        expected = ['abc', 'd e', 'fg']
+        self.assertEqual(expected, split_to_chunks(iterable, chunk_size))
+
     async def test_flatten(self):
         list_of_lists = [[[[]]], [], [[]], [[], []]]
         self.assertEqual([], flatten(list_of_lists))
@@ -346,3 +353,56 @@ class Test(django.test.TransactionTestCase):
         expected_values = [50, 55, 60, 65]
         actual_value = min_max_normalize(original_values, original_min, original_max, new_min, new_max)
         self.assertEqual(expected_values, actual_value)
+
+    def test_find_offsets(self):
+        text = 'Test\n\n123'
+        self.assertEqual(4, next(find_start_indexes(text, '\n\n')))
+
+        text = 'Test\n\n123\n\n'
+        self.assertEqual([4, 9], list(find_start_indexes(text, '\n\n')))
+
+    def test_split_text_keep_code_blocks_only_spaces(self):
+        # Basic idea. Try to keep as much intact content in each message.
+        # First cases: should split at white space if able. If there is no white space inside given split range,
+        # does a hard split at the limit
+        text = '1234 1234 12 Bar'
+        self.assertEqual(['1234 1234 12 Bar'], split_text_keep_text_blocks(text, 3, 20))
+        self.assertEqual(['1234 1234 12', 'Bar'], split_text_keep_text_blocks(text, 3, 15))
+        self.assertEqual(['1234 1234', '12 Bar'], split_text_keep_text_blocks(text, 3, 10))
+        self.assertEqual(['1234', '1234', '12 Bar'], split_text_keep_text_blocks(text, 3, 6))
+
+        # As a last example: When range of number of characters is 2-3, should split at last space
+        # with the limit or at the end of the limit. For the 1. chunk text is '1234 1234 12 Bar'.
+        # As the chunk can have at most 3 characters and there are no white spaced, split is done so that
+        # first chunk is '123'. When evaluating the second chunk, the text is '4 1234 12 Bar'. Now, the
+        # function starts iterating from the end limit and splits at the first space leaving only '4'
+        # for the second chunk.
+        self.assertEqual(['123', '4', '123', '4', '12', 'Bar'], split_text_keep_text_blocks(text, 2, 3))
+
+    def test_split_text_keep_code_blocks_paragraphs(self):
+        # Tries to keep paragraphs intact. If remaining text is longer than the limit,
+        # splits text at the previous paragraph break.
+        text = 'Test test\n\nFoo Bar\n\nTest test'
+        expected = ['Test test', 'Foo Bar', 'Test test']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 0, 10))
+        expected = ['Test test\n\nFoo Bar', 'Test test']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 0, 20))
+        # If min character limit is higher thant the paragraph boundaries, does a split on last
+        # white space before end of the limit
+        expected = ['Test test\n\nFoo Bar\n\nTest', 'test']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 24, 26))
+
+    def test_split_text_keep_code_blocks_code_blocks(self):
+        # Tries to keep code blocks intact. If remaining text is longer than the limit,
+        # splits text at the previous code block start if one exists within the limits.
+        text = 'Test test\n```Foo```\nTest test'
+        expected = ['Test test', '```Foo```', 'Test test']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 0, 10))
+        expected = ['Test test\n```Foo```', 'Test test']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 0, 20))
+
+        # If no code block start exists within the limit, does a hard split by closing the current code block
+        # and opening the next chunk with a new code block.
+        text = '```\nFoo Bar\n\ntest test\n```'
+        expected = ['```\nFoo Bar\n```', '```\ntest test\n```']
+        self.assertEqual(expected, split_text_keep_text_blocks(text, 10, 20))

--- a/bobweb/bob/test_utilities.py
+++ b/bobweb/bob/test_utilities.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import django
+import pytest
 from django.test import TestCase
 from telegram import Update
 from telegram.ext import CallbackContext
@@ -184,7 +186,8 @@ async def message_handler_echo_mock(update: Update, context: CallbackContext = N
 
 
 @mock.patch('bobweb.bob.message_handler.handle_update', message_handler_echo_mock)
-class TestReplyLongText(TestCase):
+@pytest.mark.asyncio
+class Test(django.test.TransactionTestCase):
     """ Tests that reply_long_text works as expected and long mesasges are
         sent as multiple messages. All Telegram API replies are mocked to be
         using reply_long_text to make testing easier.

--- a/bobweb/bob/test_utilities.py
+++ b/bobweb/bob/test_utilities.py
@@ -1,6 +1,11 @@
-from django.test import TestCase
+from unittest import mock
 
-from bobweb.bob.utils_common import get_caller_from_stack, object_search
+from django.test import TestCase
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from bobweb.bob.tests_mocks_v2 import init_chat_user
+from bobweb.bob.utils_common import get_caller_from_stack, object_search, reply_long_text_with_markdown
 
 
 def func_wants_to_know_who_called():
@@ -168,3 +173,37 @@ class TestDictSearch(TestCase):
             self.assertEqual(object_search(data, 'foo', 'bar', 0, 'baz', default=101), 42)
             # Invalid path and default value is given => default is returned
             self.assertEqual(object_search(data, 'invalid_path', default=101), 101)
+
+
+async def message_handler_echo_mock(update: Update, context: CallbackContext = None):
+    # Maximum length is total maximum allowed length for message. As each message will
+    # contain a footer indicating its number and total number of messages, content of
+    # messages will be shorter than the given msg_max_length (by 10 characters)
+    await reply_long_text_with_markdown(update, update.effective_message.text,
+                                        quote=False, min_msg_length=10, max_msg_length=35)
+
+
+@mock.patch('bobweb.bob.message_handler.handle_update', message_handler_echo_mock)
+class TestReplyLongText(TestCase):
+    """ Tests that reply_long_text works as expected and long mesasges are
+        sent as multiple messages. All Telegram API replies are mocked to be
+        using reply_long_text to make testing easier.
+        For this classes test cases normal message_handler is mock patched with
+        a version that just echoes users input sent with reply_long_text."""
+
+    async def test_short_message_is_sent_as_is(self):
+        chat, user = init_chat_user()
+        await user.send_message('test')
+        self.assertEqual('test', chat.last_bot_txt())
+        self.assertEqual(1, len(chat.bot.messages))
+
+    async def test_long_message_is_sent_in_multiple_messages(self):
+        chat, user = init_chat_user()
+        # If message with 40 asterisks is sent, it is split at predefined maximum length of 35 - 10 = 25 characters.
+        # Second message will contain the rest.
+        await user.send_message('*' * 40)
+        self.assertEqual('*' * 25 + '\n(1/2)', chat.bot.messages[-2].text)
+        self.assertEqual('*' * 15 + '\n(2/2)', chat.bot.messages[-1].text)
+        self.assertEqual(2, len(chat.bot.messages))
+
+

--- a/bobweb/bob/test_utilities.py
+++ b/bobweb/bob/test_utilities.py
@@ -206,4 +206,7 @@ class TestReplyLongText(TestCase):
         self.assertEqual('*' * 15 + '\n(2/2)', chat.bot.messages[-1].text)
         self.assertEqual(2, len(chat.bot.messages))
 
+        # Check that the last message sent by bot is replying to the first message
+        self.assertEqual(chat.bot.messages[-1].reply_to_message.id, chat.bot.messages[-2].id)
+
 

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -9,11 +9,11 @@ from typing import List, Sized, Tuple, Optional, Iterable
 import pytz
 from django.db.models import QuerySet
 from telegram import Message, Update, Chat
-from telegram.constants import ChatAction
+from telegram.constants import ChatAction, ParseMode
 from telegram.ext import CallbackContext
 from xlsxwriter.utility import datetime_to_excel_datetime
 
-from bobweb.bob.resources.bob_constants import FINNISH_DATE_FORMAT, fitz
+from bobweb.bob.resources.bob_constants import FINNISH_DATE_FORMAT, fitz, TELEGRAM_MESSAGE_MAX_LENGTH
 
 logger = logging.getLogger(__name__)
 
@@ -84,24 +84,157 @@ def find_first_not_none(iterable: List[any]) -> Optional[any]:
     return None
 
 
-def split_to_chunks(iterable: List, chunk_size: int):
-    if iterable is None:
-        return []
-    if chunk_size <= 0:
-        return iterable
-
-    list_of_chunks = []
-    for i in range(0, len(iterable), chunk_size):
-        list_of_chunks.append(iterable[i:i + chunk_size])
-    return list_of_chunks
-
-
 def flatten(item: any) -> List:
     if not item:  # Empty list or None
         return item
     if isinstance(item[0], list) or isinstance(item[0], tuple):
         return flatten(item[0]) + flatten(item[1:])
     return item[:1] + flatten(item[1:])
+
+
+def split_to_chunks(sized_obj: Optional[Sized], chunk_size: int) -> List:
+    """
+    Splits given sized object into chunks of given size
+    :param sized_obj: any object that is Sized
+    :param chunk_size: positive integer. If None or 0, returns empty list
+    :return: list with the chunks
+    """
+    if not sized_obj or not chunk_size or chunk_size <= 0:
+        return []
+    list_of_chunks = []
+    for i in range(0, len(sized_obj), chunk_size):
+        list_of_chunks.append(sized_obj[i:i + chunk_size])
+    return list_of_chunks
+
+
+async def reply_long_text_with_markdown(update: Update,
+                                        text: str,
+                                        quote: bool = False,
+                                        min_msg_length: int = 1024,
+                                        max_msg_length: int = TELEGRAM_MESSAGE_MAX_LENGTH):
+    """
+    Wrapper for Python Telegram Bot API's Message#reply_text that can handle
+    long replies that contain messages with content length near or over Telegram's
+    message content limit of 1024/4096 characters. If text is near the limit it is
+    split into multiple messages that are decorated with number of current message
+    and number of total messages. For example "[message content]... (1 / 2)".
+
+    This function tries to keep text block elements in the same message (paragraphs
+    and code blocks). Sends message using PTB ParseMode.MARKDOWN.
+    """
+    if len(text) <= max_msg_length:
+        return await update.effective_message.reply_text(text, quote=quote, parse_mode=ParseMode.MARKDOWN)
+
+    # Total maximum message length is reduced by 20 characters to leave room for the footer of the message.
+    chunks = split_text_keep_text_blocks(text, min_msg_length, max_msg_length - 10)
+    chunk_count = len(chunks)
+    # Each sent message is sent as reply to the previous message so that reply chains are kept intact
+    previous_message: Optional[Message] = None
+    for i, chunk in enumerate(chunks):
+        msg = chunk + f'\n({i + 1}/{chunk_count})'
+        if i == 0:
+            previous_message = await update.effective_message.reply_text(
+                msg, quote=quote, parse_mode=ParseMode.MARKDOWN)
+        elif previous_message:
+            # After first message, bot replies to its own previous message
+            previous_message = await previous_message.reply_text(msg, quote=quote, parse_mode=ParseMode.MARKDOWN)
+
+
+def split_text_keep_text_blocks(text: str, min_msg_characters: int, max_msg_characters: int):
+    """
+    Splits given text to list of text chunks. Tries not to split a code block or a paragraph to
+    different messages. Splits at last fitting boundary inside the given character index range
+    for each message. If no fitting boundary is found inside the range, does a hard cut at the
+    range end. If there is a code block open at the range end, adds ending markdown and starts next
+    message with a code block. Priority of boundaries is as follows:
+    1. Last paragraph change if not inside code block
+    2. Last code block start if range end is inside the code block
+    3. Hard split inside code block or paragraph if there is no fitting boundary inside the split range
+    Note: In Markdown code blocks cannot be nested.
+    :param text: any text
+    :param min_msg_characters: soft limit starting from which text can be split
+    :param max_msg_characters: hard limit for splitting the text. If no boundary is found between
+                       soft and hard limits, text is split at the hard limit.
+    :return: list of text chunks
+    """
+    code_block_boundary = '```'
+    double_line_change = '\n\n'
+    code_block_start_tag = '```\n'
+    code_block_end_tag = '\n```'
+    chunks = []
+
+    while text and text != '':
+        if len(text) <= max_msg_characters:
+            chunks.append(text)
+            return chunks
+
+        # Etitään kaikki saulat / rajat
+        all_code_block_boundary_indexes = [i for i in find_start_indexes(text, code_block_boundary)]
+
+        # Tän jälkeen etsitään ensimmäinen, jonka indeksi on suurempi kuin limitti
+        next_code_block_boundary_after_limit = None
+        for b_index, character_index_in_text in enumerate(all_code_block_boundary_indexes):
+            if character_index_in_text >= max_msg_characters:
+                next_code_block_boundary_after_limit = b_index
+                break
+
+        # If next code block boundary after limit exists and it is even (closing boundary, +1 for 0-starting indexing),
+        # it means that the limit is inside the code block
+        if next_code_block_boundary_after_limit and (next_code_block_boundary_after_limit + 1) % 2 == 0:
+            # If next boundary over the limit is a closing code block, this means that the limit is inside the code
+            # block. In this case, we split before that code block if it's start is before the split range start
+            previous_boundary = all_code_block_boundary_indexes[next_code_block_boundary_after_limit - 1]
+
+            if previous_boundary > min_msg_characters:
+                chunks.append(text[:previous_boundary])
+                text = text[previous_boundary:].strip()
+            else:
+                # Previous boundary is before the split range start. We split the code block at the last double
+                # line change. Find last line change inside the limit (-4 so that ending code block can be added)
+                line_changes = [i for i in find_start_indexes(text, double_line_change)
+                                if min_msg_characters < i < max_msg_characters - len(code_block_end_tag)]
+                split_index = line_changes[-1] \
+                    if line_changes and line_changes[-1] > len(code_block_start_tag) else max_msg_characters
+                chunks.append(text[:split_index] + code_block_end_tag)
+                text = code_block_start_tag + text[split_index:].strip()
+        else:
+            # Either no closing code block boundaries over the limit or no code block boundaries at all.
+            # Split at last paragraph
+            paragraph_boundaries_before_limit = [i for i in find_start_indexes(text, double_line_change)
+                                                 if min_msg_characters < i < max_msg_characters]
+            if paragraph_boundaries_before_limit:
+                split_index = paragraph_boundaries_before_limit[-1]
+                chunks.append(text[:split_index])
+                text = text[split_index:].strip()
+                continue
+            # As last cause, split at last white space character before the limit
+
+            i = max_msg_characters - 1
+            while i >= min_msg_characters - 1:
+                if text[i].isspace():
+                    chunks.append(text[:i])
+                    text = text[i:].strip()
+                    break
+                i -= 1
+            # Case where there is no white space character before the limit
+            if i < min_msg_characters - 1:
+                split_index = max_msg_characters
+                chunks.append(text[:split_index])
+                text = text[split_index:].strip()
+    return chunks
+
+
+def find_start_indexes(text, search_string):
+    """
+    Find the start of all (possibly-overlapping) instances of needle in haystack
+    """
+    offs = -1
+    while True:
+        offs = text.find(search_string, offs+1)
+        if offs == -1:
+            break
+        else:
+            yield offs
 
 
 def min_max_normalize(value_or_iterable: Decimal | int | List[Decimal | int] | List[List],

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -136,8 +136,8 @@ async def reply_long_text_with_markdown(update: Update,
             previous_message = await update.effective_message.reply_text(
                 msg, quote=quote, parse_mode=ParseMode.MARKDOWN)
         elif previous_message:
-            # After first message, bot replies to its own previous message
-            previous_message = await previous_message.reply_text(msg, quote=quote, parse_mode=ParseMode.MARKDOWN)
+            # After first message, bot replies to its own previous message. Quote=True => is sent as reply
+            previous_message = await previous_message.reply_text(msg, quote=True, parse_mode=ParseMode.MARKDOWN)
 
 
 def split_text_keep_text_blocks(text: str, min_msg_characters: int, max_msg_characters: int):

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -184,9 +184,8 @@ def split_text_keep_text_blocks(text: str, min_msg_characters: int, max_msg_char
             # If next boundary over the limit is a closing code block, this means that the limit is inside the code
             # block. In this case, we split before that code block if it's start is before the split range start
             previous_boundary = all_code_block_boundary_indexes[next_code_block_boundary_after_limit - 1]
-
             if previous_boundary > min_msg_characters:
-                chunks.append(text[:previous_boundary])
+                chunks.append(text[:previous_boundary].strip())
                 text = text[previous_boundary:].strip()
             else:
                 # Previous boundary is before the split range start. We split the code block at the last double


### PR DESCRIPTION
- Adds support for splitting long gpt responses to multiple chunks and sending those in multiple messages each replying to the previous one. Messages are split in a way that keeps code block, paragraphs and words intact in each message if possible.