### PR TITLE
New '/ip'-command to get running environment public IP-address

### DIFF
--- a/bobweb/bob/command_ip_address.py
+++ b/bobweb/bob/command_ip_address.py
@@ -1,0 +1,37 @@
+import requests
+from telegram import Update
+from telegram.ext import CallbackContext
+
+from bobweb.bob import database
+from bobweb.bob.command import ChatCommand, regex_simple_command
+
+
+class IpAddressCommand(ChatCommand):
+    """
+    Command for getting ip-address for the running environment
+    """
+    def __init__(self):
+        super().__init__(
+            name='ip',
+            regex=regex_simple_command('ip'),  # Note! No command prefix
+            help_text_short=None  # Not shown in help command list
+        )
+
+    def is_enabled_in(self, chat):
+        # Only enabled in error log chat
+        error_log_chat = database.get_the_bob().error_log_chat
+        return error_log_chat and error_log_chat.id == chat.id
+
+    async def handle_update(self, update: Update, context: CallbackContext = None):
+        reply_text = "IP-osoitteen haku epäonnistui."
+        try:
+            response = requests.get('https://api.ipify.org')
+            if response.status_code == 200:
+                reply_text = f'IP-osoite on: {response.text} 📟'
+            else:
+                reply_text += f'\napi.ipify.org vastasi statuksella: {response.status_code}'
+        except requests.exceptions.RequestException as e:
+            reply_text += f"\nVirhe: {str(e)}"
+        await update.effective_chat.send_message(reply_text)
+
+

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -15,6 +15,7 @@ from bobweb.bob.command_image_generation import DalleMiniCommand, DalleCommand
 from bobweb.bob.command_help import HelpCommand
 from bobweb.bob.command_huoneilma import HuoneilmaCommand
 from bobweb.bob.command_huutista import HuutistaCommand
+from bobweb.bob.command_ip_address import IpAddressCommand
 from bobweb.bob.command_kunta import KuntaCommand
 from bobweb.bob.command_leet import LeetCommand
 from bobweb.bob.command_or import OrCommand
@@ -98,7 +99,9 @@ class CommandService:
         # 2. Return list of all commands with helpCommand added
         commands_without_help = self.create_all_but_help_command()
         help_command = HelpCommand(commands_without_help)
-        self.commands = commands_without_help + [help_command]
+        # Ip-address command is added after HelpCommand is created as
+        # it is restricted only to project maintainers
+        self.commands = commands_without_help + [help_command, IpAddressCommand()]
 
     def create_all_but_help_command(self) -> List[ChatCommand]:
         return [

--- a/bobweb/bob/test_command_help.py
+++ b/bobweb/bob/test_command_help.py
@@ -45,7 +45,7 @@ class Test(django.test.TransactionTestCase):
 
     async def test_all_commands_except_help_have_help_text_defined(self):
         for command in command_service.instance.commands:
-            if command.name != 'help':
+            if command.name not in ['help', 'ip']:
                 self.assertIsNotNone(command.help_text_short)
                 self.assertEqual(len(command.help_text_short), 2)  # Tuple has 2 items - name and description
                 self.assertRegex(command.help_text_short[0], r'' + command.name)

--- a/bobweb/bob/test_command_ip_address.py
+++ b/bobweb/bob/test_command_ip_address.py
@@ -1,0 +1,89 @@
+from unittest import mock
+from unittest.mock import patch
+
+import django
+import pytest
+import requests
+from django.core import management
+from django.test import TestCase
+from requests import RequestException
+
+import bobweb.bob.command_ip_address
+from bobweb.bob import database
+from bobweb.bob.command_ip_address import IpAddressCommand
+from bobweb.bob.tests_mocks_v2 import init_chat_user
+from bobweb.bob.tests_utils import assert_command_triggers, MockResponse
+
+
+class IpCommandApiEndpointPingTest(TestCase):
+    """ Smoke test against the real api """
+
+    async def test_epic_games_api_endpoint_ok(self):
+        res = requests.get('https://api.ipify.org')
+        self.assertEqual(200, res.status_code)
+
+
+@pytest.mark.asyncio
+@mock.patch('requests.get', lambda *args, **kwargs: MockResponse(status_code=200, text='1.2.3.4'))
+class IpAddressCommandTests(django.test.TransactionTestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(IpAddressCommandTests, cls).setUpClass()
+        management.call_command('migrate')
+
+    async def test_should_be_enabled_only_in_specified_chat(self):
+        # Command should only be enabled in predefined chats
+        chat, user = init_chat_user()
+
+        # As new chat is created it is not set as the error_log_chat.
+        bob = database.get_the_bob()
+        self.assertIsNone(bob.error_log_chat)
+
+        # Bot should not respond anything.
+        await user.send_message('/ip')
+        self.assertEqual(0, len(chat.bot.messages))
+
+        # Now if the chat is set as the error_log_chat, bot should respond
+        bob.error_log_chat = database.get_chat(chat.id)
+        bob.save()
+        await user.send_message('/ip')
+        self.assertEqual('IP-osoite on: 1.2.3.4 📟', chat.last_bot_txt())
+        self.assertEqual(1, len(chat.bot.messages))
+
+
+@pytest.mark.asyncio
+# By default, if nothing else is defined, all request.get requests are returned with this mock
+@mock.patch('requests.get', lambda *args, **kwargs: MockResponse(status_code=200, text='1.2.3.4'))
+@patch.object(bobweb.bob.command_ip_address.IpAddressCommand, 'is_enabled_in', lambda self, chat: True)
+class IpAddressCommandTestsWithMocks(django.test.TransactionTestCase):
+    command_class = IpAddressCommand
+    command_str = 'ip'
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super(IpAddressCommandTestsWithMocks, cls).setUpClass()
+        management.call_command('migrate')
+
+    async def test_command_triggers(self):
+        should_trigger = [f'/{self.command_str}', f'!{self.command_str}', f'.{self.command_str}',
+                          f'/{self.command_str.upper()}']
+        should_not_trigger = [f'{self.command_str}', f'test /{self.command_str}', f'/{self.command_str} test']
+        await assert_command_triggers(self, self.command_class, should_trigger, should_not_trigger)
+
+    async def test_should_inform_if_fetch_failed(self):
+        with mock.patch('requests.get', lambda *args, **kwargs: MockResponse(status_code=404)):
+            chat, user = init_chat_user()
+            await user.send_message('/ip')
+            expected_reply = 'IP-osoitteen haku epäonnistui.\napi.ipify.org vastasi statuksella: 404'
+            self.assertEqual(expected_reply, chat.last_bot_txt())
+
+    async def test_should_inform_if_exception_was_raised(self):
+        def raise_exception(*args, **kwargs):
+            raise RequestException('test exception')
+
+        with mock.patch('requests.get', raise_exception):
+            chat, user = init_chat_user()
+            await user.send_message('/ip')
+            expected_reply = 'IP-osoitteen haku epäonnistui.\nVirhe: test exception'
+            self.assertEqual(expected_reply, chat.last_bot_txt())


### PR DESCRIPTION
Added new '/ip'-command that is available only in predefined error log chat. Returns current public IP-address of the running environment