### PR TITLE
Replace gpt 3.5 turbo with gpt 4o mini

### DIFF
--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -40,9 +40,8 @@ class GptCommand(ChatCommand):
     def __init__(self):
         super().__init__(
             name='gpt',
-            # 'gpt' with optional 3, 3.5 or 4 in the end
-            regex=regex_simple_command_with_parameters(r'gpt(3)?(\.5)?4?'),
-            help_text_short=('!gpt[3|4]', '[|1|2|3] [prompt] -> (gpt3.5|4) vastaus')
+            regex=regex_simple_command_with_parameters('gpt'),
+            help_text_short=('!gpt', '[|1|2|3] [prompt] -> (gpt) vastaus')
         )
 
     async def handle_update(self, update: Update, context: CallbackContext = None):

--- a/bobweb/bob/openai_api_utils.py
+++ b/bobweb/bob/openai_api_utils.py
@@ -83,13 +83,13 @@ def msg_serializer_for_vision_models(message: GptChatMessage) -> dict[str, str]:
     return {'role': message.role.value, 'content': content}
 
 
-gpt_3_16k = GptModel(
-    name='gpt-3.5-turbo-0125',
-    major_version=3,
+gpt_4o_mini = GptModel(
+    name='gpt-4o-mini',
+    major_version=4,
     has_vision_capabilities=False,
-    token_limit=16_385,
-    input_token_price=0.0005,
-    output_token_price=0.0015,
+    token_limit=128_000,
+    input_token_price=0.00015,
+    output_token_price=0.0006,
     message_serializer=msg_serializer_for_text_models
 )
 
@@ -115,7 +115,7 @@ gpt_4o_vision = GptModel(
 
 # All gpt models available for the bot to use. In priority from the lowest major version to the highest.
 # Order inside major versions is by vision capability and then by token limit in ascending order.
-ALL_GPT_MODELS = [gpt_3_16k, gpt_4o, gpt_4o_vision]
+ALL_GPT_MODELS = [gpt_4o_mini, gpt_4o, gpt_4o_vision]
 
 
 def determine_suitable_model_for_version_based_on_message_history(version: str,
@@ -130,7 +130,8 @@ def determine_suitable_model_for_version_based_on_message_history(version: str,
     """
     match version:
         case '3' | '3.5':
-            model = gpt_3_16k
+            # upgrade to 4 anyway
+            model = gpt_4o_mini
         case _:
             model = gpt_4o
 
@@ -298,7 +299,7 @@ class OpenAiApiState:
     token count exceeds default models limit.
 """
 # Tiktoken: BPE tokeniser for use with OpenAi's models: https://github.com/openai/tiktoken
-# cl100k_base works for both 'gpt-3.5-turbo' and 'gpt-4'
+# cl100k_base works for at least 'gpt-4'
 tiktoken_default_encoding_name = 'cl100k_base'
 
 

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -91,8 +91,8 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         bobweb.bob.config.openai_api_key = 'DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'
 
     async def test_command_triggers(self):
-        should_trigger = ['/gpt', '!gpt', '.gpt', '/GPT', '/gpt test', '/gpt3', '/gpt3.5', '/gpt4']
-        should_not_trigger = ['gpt', 'test /gpt', '/gpt2', '/gpt3.0', '/gpt4.0', '/gpt5']
+        should_trigger = ['/gpt', '!gpt', '.gpt', '/GPT', '/gpt test', '/gpt']
+        should_not_trigger = ['gpt', 'test /gpt', '/gpt2', '/gpt3', '/gpt3.0', '/gpt3.5', '/gpt4', '/gpt4.0', '/gpt5']
         await assert_command_triggers(self, GptCommand, should_trigger, should_not_trigger)
 
     async def test_get_given_parameter(self):
@@ -365,9 +365,6 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
     def test_determine_used_model_based_on_command_and_context(self):
         determine = determine_used_model
 
-        self.assertEqual('gpt-3.5-turbo-0125', determine('/gpt3 test', []).name)
-        self.assertEqual('gpt-3.5-turbo-0125', determine('/gpt3.5 test', []).name)
-
         self.assertEqual('gpt-4o', determine('/gpt test', []).name)
         # Would not trigger the command, but just to showcase, that default is used for every other case
         self.assertEqual('gpt-4o', determine('/gpt3. test', []).name)
@@ -387,11 +384,6 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_messages)
             await user.send_message('/gpt4 test')
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_messages)
-
-            await user.send_message('/gpt3 test')
-            assert_gpt_api_called_with(mock_method, model='gpt-3.5-turbo-0125', messages=expected_messages)
-            await user.send_message('/gpt3.5 test')
-            assert_gpt_api_called_with(mock_method, model='gpt-3.5-turbo-0125', messages=expected_messages)
 
     async def test_message_with_image(self):
         """


### PR DESCRIPTION
New model to replace gpt 3.5 turbo

https://openai.com/index/gpt-4o-mini-advancing-cost-efficient-intelligence/

https://platform.openai.com/docs/models
> Our affordable and intelligent small model for fast, lightweight tasks
> Text and image input, text output
> 128k context length
> Input: $0.15 | Output: $0.60*