### PR TITLE
Fix bug where malformed CommandActivity caused repeating exception

### DIFF
--- a/bobweb/bob/activities/command_activity.py
+++ b/bobweb/bob/activities/command_activity.py
@@ -31,17 +31,13 @@ class CommandActivity:
     - There can be 1 activity / users message. ActivityStates are stored in memory in CommandService's instance
     """
 
-    def __init__(self, initial_update=None, host_message: Message = None):
-        self.state: Optional['ActivityState'] = None
+    def __init__(self, initial_update):
         # Initial update (that initiated this activity)
         self.initial_update: Update = initial_update
         # Message that "hosts" the activity (is updated when state changes and contains possible inline buttons)
-        self.host_message: Message = host_message
-
-    async def start_with_state(self, state: 'ActivityState'):
-        # Change and execute first state
-        if has(state):
-            await self.change_state(state)
+        self.host_message: Message | None = None
+        # First state for the CommandActivity. Not set in constructor as executing the state requires async context
+        self.state: Optional['ActivityState'] = None
 
     async def delegate_response(self, update: Update, context: CallbackContext = None):
         # Handle callback query (inline buttons) or reply to host message

--- a/bobweb/bob/activities/command_activity.py
+++ b/bobweb/bob/activities/command_activity.py
@@ -96,6 +96,18 @@ class CommandActivity:
             await self.send_or_update_host_message(markup=InlineKeyboardMarkup([]))
         command_service.instance.remove_activity(self)
 
+    def create_activity_string_presentation(self) -> str:
+        """ String representation for situations where host message is none. """
+        initial_update_str = 'none'
+        if self.initial_update:
+            initial_update_str = (f'chat id: {self.initial_update.effective_chat.id}, '
+                                  f'message id: {self.initial_update.effective_message.id}')
+
+        host_message_str = 'none'
+        if self.host_message:
+            host_message_str = f'chat id: {self.host_message.chat.id}, message id: {self.host_message.id}'
+        return f"state: {self.state}, initial update: {initial_update_str}, host message: {host_message_str}"
+
     #
     # Lower abstraction implementation details
     #
@@ -146,7 +158,8 @@ class CommandActivity:
                 new_message = InputMediaPhoto(media=image, caption=new_text, parse_mode=parse_mode)
                 return await self.host_message.edit_media(media=new_message, reply_markup=markup)
             else:
-                return await self.host_message.edit_caption(caption=new_text, reply_markup=markup, parse_mode=parse_mode)
+                return await self.host_message.edit_caption(caption=new_text, reply_markup=markup,
+                                                            parse_mode=parse_mode)
 
         if new_text == self.host_message.text and markup == self.host_message.reply_markup:
             return self.host_message  # nothing to update

--- a/bobweb/bob/activities/command_activity.py
+++ b/bobweb/bob/activities/command_activity.py
@@ -96,18 +96,6 @@ class CommandActivity:
             await self.send_or_update_host_message(markup=InlineKeyboardMarkup([]))
         command_service.instance.remove_activity(self)
 
-    def create_activity_string_presentation(self) -> str:
-        """ String representation for situations where host message is none. """
-        initial_update_str = 'none'
-        if self.initial_update:
-            initial_update_str = (f'chat id: {self.initial_update.effective_chat.id}, '
-                                  f'message id: {self.initial_update.effective_message.id}')
-
-        host_message_str = 'none'
-        if self.host_message:
-            host_message_str = f'chat id: {self.host_message.chat.id}, message id: {self.host_message.id}'
-        return f"state: {self.state}, initial update: {initial_update_str}, host message: {host_message_str}"
-
     #
     # Lower abstraction implementation details
     #
@@ -158,8 +146,7 @@ class CommandActivity:
                 new_message = InputMediaPhoto(media=image, caption=new_text, parse_mode=parse_mode)
                 return await self.host_message.edit_media(media=new_message, reply_markup=markup)
             else:
-                return await self.host_message.edit_caption(caption=new_text, reply_markup=markup,
-                                                            parse_mode=parse_mode)
+                return await self.host_message.edit_caption(caption=new_text, reply_markup=markup, parse_mode=parse_mode)
 
         if new_text == self.host_message.text and markup == self.host_message.reply_markup:
             return self.host_message  # nothing to update

--- a/bobweb/bob/command_sahko.py
+++ b/bobweb/bob/command_sahko.py
@@ -33,7 +33,7 @@ class SahkoCommand(ChatCommand):
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
         await send_bot_is_typing_status_update(update.effective_chat)
-        await bobweb.bob.command_service.instance.start_new_activity(update, SahkoBaseState())
+        await bobweb.bob.command_service.instance.start_new_activity(update, context, SahkoBaseState())
 
 
 async def create_message_with_preview() -> MessageWithPreview:

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -98,7 +98,8 @@ class CommandService:
             # and if so, it is logged to the console.
             host_message = activity.host_message  # message that contains inline keyboard and is interactive
             if host_message is None:
-                logger.warning(f"Host message is None for activity {activity.create_activity_string_presentation()}")
+                logger.warning(f"CommandService current activities had an activity without host message. "
+                               f"Host message is None for activity {activity.create_activity_string_presentation()}")
                 activities_to_remove.append(activity)
             elif host_message.message_id == message_id and host_message.chat_id == chat_id:
                 target_activity = activity

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -80,7 +80,7 @@ class CommandService:
                                  initial_state: ActivityState):
         activity: CommandActivity = CommandActivity(initial_update=initial_update)
         await activity.change_state(initial_state)
-        if False:
+        if activity.host_message is not None:
             self.current_activities.append(activity)
         else:
             warning_message = ("Started new CommandActivity for which its initial state did not create a host message. "

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -90,29 +90,18 @@ class CommandService:
             pass  # Not found -> already removed or never added. Nothing to do.
 
     def get_activity_by_message_and_chat_id(self, message_id: int, chat_id: int) -> Optional[CommandActivity]:
-        target_activity: Optional[CommandActivity] = None
-        activities_to_remove = []
         for activity in self.current_activities:
             # NOTE! There has been a bug in production, where current_activities contains an activity without
             # host_message. This should be fixed in the future. As a workaround, we check if host_message is None
             # and if so, it is logged to the console.
             host_message = activity.host_message  # message that contains inline keyboard and is interactive
             if host_message is None:
-                logger.warning(f"Host message is None for activity {activity.create_activity_string_presentation()}")
-                activities_to_remove.append(activity)
+                logger.warning(f"Host message is None for activity {activity}\n"
+                               f"{json.dumps(activity)}")
             elif host_message.message_id == message_id and host_message.chat_id == chat_id:
-                target_activity = activity
-                break
-
-        # If problematic activities were found, remove them
-        for activity in activities_to_remove:
-            try:
-                self.current_activities.remove(activity)
-            except ValueError:
-                pass  # Already removed -> exception ignored
-
+                return activity
         # If no matching activity is found, return None
-        return target_activity
+        return None
 
     def create_command_objects(self):
         # 1. Define all commands (except help, as it is dependent on the others)

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -98,8 +98,7 @@ class CommandService:
             # and if so, it is logged to the console.
             host_message = activity.host_message  # message that contains inline keyboard and is interactive
             if host_message is None:
-                logger.warning(f"CommandService current activities had an activity without host message. "
-                               f"Host message is None for activity {activity.create_activity_string_presentation()}")
+                logger.warning(f"Host message is None for activity {activity.create_activity_string_presentation()}")
                 activities_to_remove.append(activity)
             elif host_message.message_id == message_id and host_message.chat_id == chat_id:
                 target_activity = activity

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -90,18 +90,29 @@ class CommandService:
             pass  # Not found -> already removed or never added. Nothing to do.
 
     def get_activity_by_message_and_chat_id(self, message_id: int, chat_id: int) -> Optional[CommandActivity]:
+        target_activity: Optional[CommandActivity] = None
+        activities_to_remove = []
         for activity in self.current_activities:
             # NOTE! There has been a bug in production, where current_activities contains an activity without
             # host_message. This should be fixed in the future. As a workaround, we check if host_message is None
             # and if so, it is logged to the console.
             host_message = activity.host_message  # message that contains inline keyboard and is interactive
             if host_message is None:
-                logger.warning(f"Host message is None for activity {activity}\n"
-                               f"{json.dumps(activity)}")
+                logger.warning(f"Host message is None for activity {activity.create_activity_string_presentation()}")
+                activities_to_remove.append(activity)
             elif host_message.message_id == message_id and host_message.chat_id == chat_id:
-                return activity
+                target_activity = activity
+                break
+
+        # If problematic activities were found, remove them
+        for activity in activities_to_remove:
+            try:
+                self.current_activities.remove(activity)
+            except ValueError:
+                pass  # Already removed -> exception ignored
+
         # If no matching activity is found, return None
-        return None
+        return target_activity
 
     def create_command_objects(self):
         # 1. Define all commands (except help, as it is dependent on the others)

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import List, Optional
 
@@ -77,16 +76,17 @@ class CommandService:
 
     async def start_new_activity(self,
                                  initial_update: Update,
+                                 context: CallbackContext,
                                  initial_state: ActivityState):
         activity: CommandActivity = CommandActivity(initial_update=initial_update)
         await activity.change_state(initial_state)
-        if activity.host_message is not None:
+        if False:
             self.current_activities.append(activity)
         else:
             warning_message = ("Started new CommandActivity for which its initial state did not create a host message. "
                                "InitialState: " + str(initial_state.__class__) if initial_state else 'None')
             logger.warning(warning_message)
-            await error_handler.send_message_to_error_log_chat(initial_update.get_bot(), warning_message)
+            await error_handler.send_message_to_error_log_chat(context, warning_message)
 
     def remove_activity(self, activity: CommandActivity):
         try:

--- a/bobweb/bob/command_service.py
+++ b/bobweb/bob/command_service.py
@@ -6,7 +6,7 @@ from telegram import Update, InlineKeyboardMarkup
 from telegram.constants import ParseMode
 from telegram.ext import CallbackContext
 
-from bobweb.bob import main, command_gpt
+from bobweb.bob import main, command_gpt, error_handler
 from bobweb.bob.activities.activity_state import ActivityState
 from bobweb.bob.activities.command_activity import CommandActivity
 from bobweb.bob.command import ChatCommand
@@ -33,7 +33,6 @@ from bobweb.bob.command_daily_question import DailyQuestionHandler, DailyQuestio
 from bobweb.bob.command_epic_games import EpicGamesOffersCommand
 from bobweb.bob.command_twitch import TwitchCommand
 from bobweb.bob.utils_common import has
-
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ class CommandService:
             await target_activity.delegate_response(update, context)
             return True
         elif has(update.callback_query):
-            # If has a callback query, it means that the update is a inline keyboard button press.
+            # If the received update has a callback query, it means that the update is an inline keyboard button press.
             # As the ChatActivity state is no longer persisted in the command_service instance, we'll update
             # content of the message that had the pressed button.
             edited_text = 'Toimenpide aikakatkaistu ⌛️ Aloita se uudelleen uudella komennolla.'
@@ -80,8 +79,14 @@ class CommandService:
                                  initial_update: Update,
                                  initial_state: ActivityState):
         activity: CommandActivity = CommandActivity(initial_update=initial_update)
-        self.current_activities.append(activity)
-        await activity.start_with_state(initial_state)
+        await activity.change_state(initial_state)
+        if activity.host_message is not None:
+            self.current_activities.append(activity)
+        else:
+            warning_message = ("Started new CommandActivity for which its initial state did not create a host message. "
+                               "InitialState: " + str(initial_state.__class__) if initial_state else 'None')
+            logger.warning(warning_message)
+            await error_handler.send_message_to_error_log_chat(initial_update.get_bot(), warning_message)
 
     def remove_activity(self, activity: CommandActivity):
         try:
@@ -91,17 +96,10 @@ class CommandService:
 
     def get_activity_by_message_and_chat_id(self, message_id: int, chat_id: int) -> Optional[CommandActivity]:
         for activity in self.current_activities:
-            # NOTE! There has been a bug in production, where current_activities contains an activity without
-            # host_message. This should be fixed in the future. As a workaround, we check if host_message is None
-            # and if so, it is logged to the console.
             host_message = activity.host_message  # message that contains inline keyboard and is interactive
-            if host_message is None:
-                logger.warning(f"Host message is None for activity {activity}\n"
-                               f"{json.dumps(activity)}")
-            elif host_message.message_id == message_id and host_message.chat_id == chat_id:
+            if host_message and host_message.message_id == message_id and host_message.chat_id == chat_id:
                 return activity
-        # If no matching activity is found, return None
-        return None
+        return None  # If no matching activity is found, return None
 
     def create_command_objects(self):
         # 1. Define all commands (except help, as it is dependent on the others)

--- a/bobweb/bob/command_settings.py
+++ b/bobweb/bob/command_settings.py
@@ -25,7 +25,7 @@ class SettingsCommand(ChatCommand):
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
         chat = database.get_chat(update.effective_chat.id)
-        await command_service.instance.start_new_activity(update, SettingsMenuOpenState(chat))
+        await command_service.instance.start_new_activity(update, context, SettingsMenuOpenState(chat))
 
 
 toggleable_property_key = '_enabled'

--- a/bobweb/bob/command_twitch.py
+++ b/bobweb/bob/command_twitch.py
@@ -61,7 +61,7 @@ class TwitchCommand(ChatCommand):
                                                                    new_activity_state)
         new_activity_state.message_board_event_message = event_message
 
-        await command_service.instance.start_new_activity(update, new_activity_state)
+        await command_service.instance.start_new_activity(update, context, new_activity_state)
 
 
 class TwitchStreamUpdatedSteamStatusState(ActivityState):

--- a/bobweb/bob/error_handler.py
+++ b/bobweb/bob/error_handler.py
@@ -6,8 +6,9 @@ import traceback
 import telegram.error
 from telegram import Update, Bot
 from telegram.constants import ParseMode
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, Application, CallbackContext
 
+import bobweb.bob.main
 from bobweb.bob import database, message_board_service
 from bobweb.bob.message_board import MessageBoard
 from bobweb.bob.resources.unicode_emoji import get_random_emoji
@@ -15,15 +16,15 @@ from bobweb.bob.resources.unicode_emoji import get_random_emoji
 logger = logging.getLogger(__name__)
 
 
-async def send_message_to_error_log_chat(bot: Bot, text: str):
+async def send_message_to_error_log_chat(context: CallbackContext, text: str):
     """ Send message to error log chat if such is defined in the database. """
     error_log_chat = database.get_the_bob().error_log_chat
-    if error_log_chat is not None:
+    if error_log_chat is not None and context is not None:
         try:
-            await bot.send_message(chat_id=error_log_chat.id, text=text, parse_mode=ParseMode.HTML)
+            await context.bot.send_message(chat_id=error_log_chat.id, text=text)
         except telegram.error.BadRequest as e:
             logger.error('Exception while sending message to error log chat. '
-                         'Tried to send message to chat id=' + error_log_chat.id, exc_info=e)
+                         'Tried to send message to chat id=' + str(error_log_chat.id), exc_info=e)
 
 
 async def unhandled_bot_exception_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bobweb/bob/error_handler.py
+++ b/bobweb/bob/error_handler.py
@@ -44,7 +44,7 @@ async def unhandled_bot_exception_handler(update: object, context: ContextTypes.
     error_message = create_error_report_message(update, context, error_emoji_id)
 
     # Send error message to the error log chat if it is set
-    await send_message_to_error_log_chat(context.bot, error_message)
+    await send_message_to_error_log_chat(context, error_message)
 
     if isinstance(update, Update):
         # And notify users by replying to the message that caused the error

--- a/bobweb/bob/test/test_command_service.py
+++ b/bobweb/bob/test/test_command_service.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from unittest.mock import AsyncMock
 
 import django
 import pytest

--- a/bobweb/bob/test/test_command_service.py
+++ b/bobweb/bob/test/test_command_service.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import AsyncMock
 
 import django
 import pytest
@@ -7,8 +8,7 @@ from django.test import TestCase
 
 import bobweb.bob.command_service
 from bobweb.bob import command_service
-from bobweb.bob.activities.command_activity import CommandActivity
-from bobweb.bob.tests_mocks_v2 import init_chat_user, assert_buttons_equals, MockUpdate
+from bobweb.bob.tests_mocks_v2 import init_chat_user, assert_buttons_equals
 
 
 @pytest.mark.asyncio
@@ -67,25 +67,3 @@ class CommandServiceTest(django.test.TransactionTestCase):
             # There should not be any buttons anymore
             assert_buttons_equals(self, [], chat.last_user_msg())
 
-    async def test_command_activity_without_host_message_is_logged_and_removed(self):
-        """ If by any chance a command activity is created and added to the CommandService without host message,
-            this should be logged and the message removed from the command services active activities list.
-            No confirmation on how this happens, however "Bug fixes (#263)"-commit (12.1.2024) introduced a new bug
-            "TypeError: Object of type CommandActivity is not JSON serializable" when json.dump() was given a
-            CommandActivity as parameter. So in addition this verifies that that does not happen anymore. """
-        # First add new activity without host message to the services activities list
-        command_service.instance.current_activities.clear()
-        activity_without_host_message = CommandActivity(initial_update=None, host_message=None)
-        command_service.instance.current_activities.append(activity_without_host_message)
-
-        self.assertEqual(1, len(command_service.instance.current_activities))
-
-        # Create message that is reply to another message and process it with reply_and_callback_query_handler
-        chat, user = init_chat_user()
-        message = await user.send_message('test1')
-        reply_message = await user.send_message('test2', reply_to_message=message)
-        mock_update = MockUpdate(message=reply_message)
-        await command_service.instance.reply_and_callback_query_handler(mock_update)
-
-        # Now the problematic activity has been removed
-        self.assertEqual(0, len(command_service.instance.current_activities))

--- a/bobweb/bob/test/test_command_service.py
+++ b/bobweb/bob/test/test_command_service.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from unittest.mock import AsyncMock
 
 import django
 import pytest
@@ -8,7 +7,8 @@ from django.test import TestCase
 
 import bobweb.bob.command_service
 from bobweb.bob import command_service
-from bobweb.bob.tests_mocks_v2 import init_chat_user, assert_buttons_equals
+from bobweb.bob.activities.command_activity import CommandActivity
+from bobweb.bob.tests_mocks_v2 import init_chat_user, assert_buttons_equals, MockUpdate
 
 
 @pytest.mark.asyncio
@@ -67,3 +67,25 @@ class CommandServiceTest(django.test.TransactionTestCase):
             # There should not be any buttons anymore
             assert_buttons_equals(self, [], chat.last_user_msg())
 
+    async def test_command_activity_without_host_message_is_logged_and_removed(self):
+        """ If by any chance a command activity is created and added to the CommandService without host message,
+            this should be logged and the message removed from the command services active activities list.
+            No confirmation on how this happens, however "Bug fixes (#263)"-commit (12.1.2024) introduced a new bug
+            "TypeError: Object of type CommandActivity is not JSON serializable" when json.dump() was given a
+            CommandActivity as parameter. So in addition this verifies that that does not happen anymore. """
+        # First add new activity without host message to the services activities list
+        command_service.instance.current_activities.clear()
+        activity_without_host_message = CommandActivity(initial_update=None, host_message=None)
+        command_service.instance.current_activities.append(activity_without_host_message)
+
+        self.assertEqual(1, len(command_service.instance.current_activities))
+
+        # Create message that is reply to another message and process it with reply_and_callback_query_handler
+        chat, user = init_chat_user()
+        message = await user.send_message('test1')
+        reply_message = await user.send_message('test2', reply_to_message=message)
+        mock_update = MockUpdate(message=reply_message)
+        await command_service.instance.reply_and_callback_query_handler(mock_update)
+
+        # Now the problematic activity has been removed
+        self.assertEqual(0, len(command_service.instance.current_activities))


### PR DESCRIPTION
* Add check that CommandActivity without host message is never added to the CommandService's current_activities array
* Add general function for sending message to the error log chat (for logging events and such)