### PR TITLE
Add scheduled 1337 and daily question scores listing to friday afternoon

### DIFF
--- a/bobweb/bob/activities/command_activity.py
+++ b/bobweb/bob/activities/command_activity.py
@@ -1,6 +1,4 @@
-import asyncio
 import logging
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
 import telegram
@@ -9,7 +7,7 @@ from telegram.constants import ParseMode
 from telegram.ext import CallbackContext
 
 from bobweb.bob import command_service, utils_common
-from bobweb.bob.utils_common import has, utctz_from, flatten
+from bobweb.bob.utils_common import has, flatten
 
 logger = logging.getLogger(__name__)
 
@@ -163,19 +161,3 @@ class CommandActivity:
         except (NameError, AttributeError):
             return []
 
-
-# Parses date and returns it. If parameter is not valid date in any predefined format, None is returned
-def parse_dt_str_to_utctzstr(text: str) -> str | None:
-    for date_format in ('%Y-%m-%d', '%d.%m.%Y', '%m/%d/%Y'):  # 2022-01-31, 31.01.2022, 01/31/2022
-        try:
-            # As only date is relevant, this is handled as Utc datetime with time of 00:00:00
-            naive_dt = datetime.strptime(text, date_format)
-            utc_transformed_dt = utctz_from(naive_dt)
-            return str(utc_transformed_dt)
-        except ValueError:
-            pass
-    return None
-
-
-date_formats_text = 'Tuetut formaatit ovat \'vvvv-kk-pp\', \'pp.kk.vvvv\' ja \'kk/pp/vvvv\'.'
-date_invalid_format_text = f'Antamasi päivämäärä ei ole tuettua muotoa. {date_formats_text}'

--- a/bobweb/bob/activities/daily_question/daily_question_menu_states.py
+++ b/bobweb/bob/activities/daily_question/daily_question_menu_states.py
@@ -1,7 +1,7 @@
 import math
 import random
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Tuple, Optional
 
 from django.db.models import QuerySet
@@ -192,7 +192,7 @@ async def create_message_board_msg(message_board: MessageBoard, chat_id: int) ->
     :param chat_id:
     :return:
     """
-    target_datetime = datetime.utcnow()
+    target_datetime = datetime.now(timezone.utc)
     active_season: DailyQuestionSeason = database.find_active_dq_season(chat_id, target_datetime).first()
     if active_season:
         body = create_stats_for_season(active_season.id, include_choose_season_prompt=False)

--- a/bobweb/bob/activities/daily_question/date_confirmation_states.py
+++ b/bobweb/bob/activities/daily_question/date_confirmation_states.py
@@ -4,10 +4,10 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import CallbackContext
 
 from bobweb.bob.activities.activity_state import ActivityState
-from bobweb.bob.activities.command_activity import parse_dt_str_to_utctzstr, date_invalid_format_text
 from bobweb.bob.activities.daily_question.message_utils import dq_saved_msg
 from bobweb.bob.resources.bob_constants import fitz
-from bobweb.bob.utils_common import prev_weekday, has_no, dt_at_midday, fi_short_day_name, fitzstr_from
+from bobweb.bob.utils_common import prev_weekday, has_no, dt_at_midday, fi_short_day_name, fitzstr_from, \
+    parse_dt_str_to_utctzstr
 from bobweb.web.bobapp.models import DailyQuestion
 
 
@@ -65,3 +65,7 @@ def day_buttons():
         [InlineKeyboardButton(text=prev_day_text, callback_data=str(prev_day))],
         [InlineKeyboardButton(text=today_text, callback_data=str(fitz_today))]
     ]
+
+
+date_formats_text = 'Tuetut formaatit ovat \'vvvv-kk-pp\', \'pp.kk.vvvv\' ja \'kk/pp/vvvv\'.'
+date_invalid_format_text = f'Antamasi päivämäärä ei ole tuettua muotoa. {date_formats_text}'

--- a/bobweb/bob/command_daily_question.py
+++ b/bobweb/bob/command_daily_question.py
@@ -1,15 +1,14 @@
-import string
-
 from django.db.models import QuerySet
 from telegram import Update, Message
 from telegram.ext import CallbackContext
 
-from bobweb.bob import command_service, message_board_service
+from bobweb.bob import command_service
 from bobweb.bob.activities.daily_question.daily_question_errors import LastQuestionWinnerAlreadySet, \
     NoAnswerFoundToPrevQuestion, DailyQuestionWinnerSetError
 from bobweb.bob.activities.daily_question.date_confirmation_states import ConfirmQuestionTargetDate
 from bobweb.bob.activities.daily_question.message_utils import get_daily_question_notification
-from bobweb.bob.activities.daily_question.daily_question_menu_states import DQMainMenuState, DQStatsMenuState, SetSeasonStartDateState
+from bobweb.bob.activities.daily_question.daily_question_menu_states import DQMainMenuState, DQStatsMenuState, \
+    SetSeasonStartDateState
 from bobweb.bob.database import SeasonListItem
 from bobweb.web.bobapp.models import DailyQuestion, DailyQuestionAnswer
 from bobweb.bob.command import ChatCommand, regex_simple_command
@@ -193,6 +192,11 @@ class MarkAnswerCommand(ChatCommand):
         await handle_mark_message_as_answer_command(update)
 
 
+target_msg_saved_as_answer_msg = 'Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!'
+target_msg_saved_as_winning_answer_msg = 'Kohdeviesti tallennettu onnistuneesti voittaneena vastauksena sitä ' \
+                                         'edeltäneeseen päivän kysymykseen'
+
+
 async def handle_mark_message_as_answer_command(update: Update):
     message_with_answer: Message = update.effective_message.reply_to_message
     if has_no(message_with_answer):
@@ -235,8 +239,3 @@ async def handle_mark_message_as_answer_command(update: Update):
         reply_msg = target_msg_saved_as_winning_answer_msg
 
     await update.effective_chat.send_message(reply_msg)
-
-
-target_msg_saved_as_answer_msg = 'Kohdeviesti tallennettu onnistuneesti vastauksena kysymykseen!'
-target_msg_saved_as_winning_answer_msg = 'Kohdeviesti tallennettu onnistuneesti voittaneena vastauksena sitä ' \
-                                         'edeltäneeseen päivän kysymykseen'

--- a/bobweb/bob/command_message_board.py
+++ b/bobweb/bob/command_message_board.py
@@ -12,7 +12,7 @@ turn_off_message_board_for_chat_command = 'off'
 message_board_bad_parameter_help = ('Voit luoda chattiin uuden ilmoitustaulun komennolla \'/ilmoitustaulu\' '
                                     'tai kytkeä sen pois käytöstä komennolla \'/ilmoitustaulu off\'')
 tg_no_rights_to_pin_or_unpin_messages_error = 'Not enough rights to manage pinned messages in the chat'
-no_pin_rights_notification = ('Minulla ei ole oikeuskia pinnata viestejä tässä chatissa. Annathan ne ensin, jotta '
+no_pin_rights_notification = ('Minulla ei ole oikeuksia pinnata viestejä tässä chatissa. Annathan ne ensin, jotta '
                               'pystyn hallinnoimaan ilmoitustaulua.')
 
 

--- a/bobweb/bob/command_users.py
+++ b/bobweb/bob/command_users.py
@@ -10,7 +10,7 @@ from bobweb.bob.utils_format import MessageArrayFormatter
 from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob import database
 
-from bobweb.web.bobapp.models import ChatMember
+from bobweb.web.bobapp.models import ChatMember, Chat
 
 
 class UsersCommand(ChatCommand):
@@ -64,6 +64,9 @@ def create_member_array(chat_members: List[ChatMember]):
     return array_of_users
 
 
-async def create_message_board_daily_message(message_board: MessageBoard, chat_id: int) -> MessageBoardMessage:
-    body = await create_users_score_formatted_table(chat_id)
-    return MessageBoardMessage(message_board, body)
+async def create_message_board_msg(message_board: MessageBoard, chat_id: int) -> MessageBoardMessage | None:
+    # Only enabled if the chat has leet enabled and latest leet in the record
+    chat: Chat = database.get_chat(chat_id=chat_id)
+    if chat.leet_enabled and chat.latest_leet is not None:
+        body = await create_users_score_formatted_table(chat_id)
+        return MessageBoardMessage(message_board, body)

--- a/bobweb/bob/command_users.py
+++ b/bobweb/bob/command_users.py
@@ -5,6 +5,7 @@ from telegram.ext import CallbackContext
 from telegram import Update
 from telegram.constants import ParseMode
 
+from bobweb.bob.message_board import MessageWithPreview, MessageBoardMessage, MessageBoard
 from bobweb.bob.utils_format import MessageArrayFormatter
 from bobweb.bob.command import ChatCommand, regex_simple_command
 from bobweb.bob import database
@@ -21,11 +22,12 @@ class UsersCommand(ChatCommand):
         )
 
     async def handle_update(self, update: Update, context: CallbackContext = None):
-        await users_command(update)
+        content = await create_users_score_formatted_table(update.effective_chat.id)
+        await update.effective_chat.send_message(content, parse_mode=ParseMode.MARKDOWN)
 
 
-async def users_command(update: Update):
-    chat_members: List[ChatMember] = list(database.get_chat_members_for_chat(chat_id=update.effective_chat.id))
+async def create_users_score_formatted_table(chat_id: int) -> str:
+    chat_members: List[ChatMember] = list(database.get_chat_members_for_chat(chat_id=chat_id))
     chat_members = exclude_possible_bots(chat_members)
 
     headings = ['Nimi', 'A', 'K', 'V']
@@ -33,19 +35,18 @@ async def users_command(update: Update):
     member_array = create_member_array(chat_members)
     member_array.insert(0, headings)
 
-    formatter = MessageArrayFormatter('⌇ ', '=').with_truncation(28, 0)
+    formatter = (MessageArrayFormatter('⌇ ', '=')
+                 .with_truncation(28, 0))
     formatted_members_array_str = formatter.format(member_array)
 
     footer = 'A=Arvo, K=Kunnia, V=Viestit'
 
     # '\U0001F913' => nerd emoji, '```' =>  markdown code block
-    reply_text = 'Käyttäjät \U0001F913\n\n' \
-                 + '```\n' \
-                 + f'{formatted_members_array_str}' \
-                 + f'```\n' \
-                 + f'{footer}'
-
-    await update.effective_chat.send_message(reply_text, parse_mode=ParseMode.MARKDOWN)
+    return 'Käyttäjät \U0001F913\n\n' \
+        + '```\n' \
+        + f'{formatted_members_array_str}' \
+        + f'```\n' \
+        + f'{footer}'
 
 
 def exclude_possible_bots(members: List[ChatMember]):
@@ -61,3 +62,8 @@ def create_member_array(chat_members: List[ChatMember]):
     # Sort users descending in order of rank, prestige, message_count
     array_of_users.sort(key=lambda row: (-row[1], -row[2], -row[3]))
     return array_of_users
+
+
+async def create_message_board_daily_message(message_board: MessageBoard, chat_id: int) -> MessageBoardMessage:
+    body = await create_users_score_formatted_table(chat_id)
+    return MessageBoardMessage(message_board, body)

--- a/bobweb/bob/command_users.py
+++ b/bobweb/bob/command_users.py
@@ -25,7 +25,7 @@ class UsersCommand(ChatCommand):
 
 
 async def users_command(update: Update):
-    chat_members: List[ChatMember] = database.get_chat_members_for_chat(chat_id=update.effective_chat.id)
+    chat_members: List[ChatMember] = list(database.get_chat_members_for_chat(chat_id=update.effective_chat.id))
     chat_members = exclude_possible_bots(chat_members)
 
     headings = ['Nimi', 'A', 'K', 'V']

--- a/bobweb/bob/command_weather.py
+++ b/bobweb/bob/command_weather.py
@@ -167,7 +167,7 @@ def format_scheduled_message_preview(weather_data: WeatherData) -> str:
     return builder.message
 
 
-async def create_weather_scheduled_message(message_board: MessageBoard, chat_id) -> 'WeatherMessageBoardMessage':
+async def create_weather_scheduled_message(message_board: MessageBoard, chat_id: int) -> 'WeatherMessageBoardMessage':
     message = WeatherMessageBoardMessage(message_board, chat_id)
     await message.change_city_and_start_update_loop()
     return message

--- a/bobweb/bob/config.py
+++ b/bobweb/bob/config.py
@@ -1,15 +1,11 @@
 import logging
 import os
-import sys
 
 # Set root level logging
-logging_handler = logging.StreamHandler(sys.stdout)
-logging_handler.setLevel(logging.DEBUG)
 logging_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-logging_handler.setFormatter(logging.Formatter(logging_format))
-logging.getLogger().addHandler(logging_handler)
+logging.basicConfig(format=logging_format, level=logging.INFO)  # NOSONAR
 
-# Set httpx and asynctio logging to only include warning level logs.
+# Set httpx and asyncio logging to only include warning level logs.
 # Otherwise, logs telegram api update checks
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("asyncio").setLevel(logging.WARNING)

--- a/bobweb/bob/message_board.py
+++ b/bobweb/bob/message_board.py
@@ -4,7 +4,7 @@ import logging
 from typing import List, Tuple, Generator
 
 import telegram
-from telegram import LinkPreviewOptions
+from telegram import LinkPreviewOptions, Message
 from telegram.constants import ParseMode
 
 from bobweb.bob.utils_common import handle_exception
@@ -30,6 +30,7 @@ For example if weather info is shown each morning on a set time period between 8
 
 class MessageWithPreview:
     """ Simple object that contains message with preview and parse mode information. """
+
     def __init__(self,
                  body: str,
                  preview: str | None = None,
@@ -119,6 +120,8 @@ class MessageBoard:
         # Id of the message that is pinned on the top of the chat window and which is the host message for the board
         self.host_message_id = host_message_id
 
+        # Current message on the board
+        self.current_message: Message | None = None
         # Reference to the message board service instance
         self._service: 'MessageBoardService' = service
         # Current scheduled message on this board
@@ -299,21 +302,29 @@ class MessageBoard:
             content = message.preview + "\n\n" + message.body
         else:
             content = message.body
+
+        if self.current_message and self.current_message.text == content:
+            return  # No need to update if content is same as current content
+
         try:
             link_preview_options: LinkPreviewOptions = LinkPreviewOptions(prefer_small_media=True)
-            await self._service.application.bot.edit_message_text(text=content,
-                                                                  chat_id=self.chat_id,
-                                                                  message_id=self.host_message_id,
-                                                                  parse_mode=message.parse_mode,
-                                                                  link_preview_options=link_preview_options)
+            self.current_message = await self._service.application.bot.edit_message_text(
+                text=content,
+                chat_id=self.chat_id,
+                message_id=self.host_message_id,
+                parse_mode=message.parse_mode,
+                link_preview_options=link_preview_options)
         except telegram.error.BadRequest as e:
             # 'not modified' is expected when trying to update message with same content => ignored.
             if 'not modified' in e.message.lower():
-                logger.info("telegram.error.BadRequest: Tried to update message with same content. Ignored.")
+                logger.info("telegram.error.BadRequest: Tried to update message with same content. "
+                            "Error ignored as this may occur.")
+                self.current_message = None  # Empty current message just to be sure
             elif 'not found' in e.message.lower():
                 # Message has been deleted.
                 self._service.remove_board_from_service_and_chat(self)
             else:
+                self.current_message = None  # Empty current message just to be sure
                 raise e  # Unexpected error, raise again
 
     async def _set_message_to_board_if_no_notifications(self, message: MessageBoardMessage):

--- a/bobweb/bob/message_board.py
+++ b/bobweb/bob/message_board.py
@@ -309,7 +309,7 @@ class MessageBoard:
         except telegram.error.BadRequest as e:
             # 'not modified' is expected when trying to update message with same content => ignored.
             if 'not modified' in e.message.lower():
-                logger.info("Tried to update message with same content. Ignored.")
+                logger.info("telegram.error.BadRequest: Tried to update message with same content. Ignored.")
             elif 'not found' in e.message.lower():
                 # Message has been deleted.
                 self._service.remove_board_from_service_and_chat(self)

--- a/bobweb/bob/message_board_service.py
+++ b/bobweb/bob/message_board_service.py
@@ -49,19 +49,27 @@ schedule_timezone_info = zoneinfo.ZoneInfo(bob_constants.DEFAULT_TIMEZONE)
 # Default schedule for the day. Note! Times are in localized Finnish Time (UTC+2 or UTC+3, depending on DST).
 # Each time new update is scheduled, it is scheduled as Finnish time as stated below.
 default_daily_schedule = [
-    create_schedule_with_chat_context(6, 00, create_weather_scheduled_message),  # Weather
-    create_schedule(9, 00, command_sahko.create_message_with_preview),  # Electricity
-    create_schedule(13, 00, command_ruoka.create_message_board_daily_message),  # Random receipt
-    create_schedule(24, 00, good_night_wishes.create_good_night_message),  # Good night
+    create_schedule_with_chat_context(6, 0, create_weather_scheduled_message),  # Weather
+    create_schedule(9, 0, command_sahko.create_message_with_preview),  # Electricity
+    create_schedule(13, 0, command_ruoka.create_message_board_daily_message),  # Random receipt
+    create_schedule(23, 0, good_night_wishes.create_good_night_message),  # Good night
 ]
 
-# Has schedule for epic games
 thursday_schedule = [
-    create_schedule_with_chat_context(6, 00, create_weather_scheduled_message),  # Weather
-    create_schedule(9, 00, command_sahko.create_message_with_preview),  # Electricity
-    create_schedule(13, 00, command_ruoka.create_message_board_daily_message),  # Random receipt
-    create_schedule(16, 00, command_epic_games.create_message_board_daily_message),  # Epic Games
-    create_schedule(24, 00, good_night_wishes.create_good_night_message),  # Good night
+    create_schedule_with_chat_context(6, 0, create_weather_scheduled_message),  # Weather
+    create_schedule(9, 0, command_sahko.create_message_with_preview),  # Electricity
+    create_schedule(13, 0, command_ruoka.create_message_board_daily_message),  # Random receipt
+    create_schedule(16, 0, command_epic_games.create_message_board_daily_message),  # Epic Games
+    create_schedule(23, 0, good_night_wishes.create_good_night_message),  # Good night
+]
+
+friday_schedule = [
+    create_schedule_with_chat_context(6, 0, create_weather_scheduled_message),  # Weather
+    create_schedule(9, 0, command_sahko.create_message_with_preview),  # Electricity
+    create_schedule(13, 0, command_ruoka.create_message_board_daily_message),  # Random receipt
+    # 13:38 1337 scores
+    # 18:00 päivän kysymys score list
+    create_schedule(23, 0, good_night_wishes.create_good_night_message),  # Good night
 ]
 
 schedules_by_week_day = {
@@ -69,7 +77,7 @@ schedules_by_week_day = {
     1: default_daily_schedule,  # Tuesday
     2: default_daily_schedule,  # Wednesday
     3: thursday_schedule,  # Thursday
-    4: default_daily_schedule,  # Friday
+    4: friday_schedule,  # Friday
     5: default_daily_schedule,  # Saturday
     6: default_daily_schedule,  # Sunday
 }

--- a/bobweb/bob/message_board_service.py
+++ b/bobweb/bob/message_board_service.py
@@ -4,7 +4,8 @@ from typing import List, Callable, Awaitable, Tuple
 
 from telegram.ext import Application, ContextTypes
 
-from bobweb.bob import main, database, command_sahko, command_ruoka, command_epic_games, good_night_wishes
+from bobweb.bob import main, database, command_sahko, command_ruoka, command_epic_games, good_night_wishes, \
+    command_users
 from bobweb.bob.command_weather import create_weather_scheduled_message
 from bobweb.bob.message_board import MessageBoard, MessageBoardMessage, MessageWithPreview, NotificationMessage
 from bobweb.bob.resources import bob_constants
@@ -59,6 +60,7 @@ thursday_schedule = [
     create_schedule_with_chat_context(6, 0, create_weather_scheduled_message),  # Weather
     create_schedule(9, 0, command_sahko.create_message_with_preview),  # Electricity
     create_schedule(13, 0, command_ruoka.create_message_board_daily_message),  # Random receipt
+    # Epic Games announcement
     create_schedule(16, 0, command_epic_games.create_message_board_daily_message),  # Epic Games
     create_schedule(23, 0, good_night_wishes.create_good_night_message),  # Good night
 ]
@@ -68,6 +70,7 @@ friday_schedule = [
     create_schedule(9, 0, command_sahko.create_message_with_preview),  # Electricity
     create_schedule(13, 0, command_ruoka.create_message_board_daily_message),  # Random receipt
     # 13:38 1337 scores
+    create_schedule_with_chat_context(13, 38, command_users.create_message_board_daily_message),
     # 18:00 päivän kysymys score list
     create_schedule(23, 0, good_night_wishes.create_good_night_message),  # Good night
 ]

--- a/bobweb/bob/message_board_service.py
+++ b/bobweb/bob/message_board_service.py
@@ -26,13 +26,13 @@ class ScheduledMessageTiming:
     """
 
     def __init__(self,
-                 starting_from: datetime.time,
+                 local_starting_from: datetime.time,
                  # Is either function that takes board and chat_id to produce messageBoardMessage
                  # OR is provider, that provides contents of the message from which new message is created for each chat
                  message_provider: Callable[[MessageBoard, int], Awaitable[MessageBoardMessage | None]]
                                    | Callable[[], Awaitable[MessageWithPreview]],
                  is_chat_specific: bool = False):
-        self.local_starting_from = starting_from
+        self.local_starting_from = local_starting_from
         self.message_provider = message_provider
         # If scheduled message is chat specific, each message is created separately for each board and the chat id is
         # given as a parameter to the message_provider. Otherwise, the scheduled message is created only once and the
@@ -40,26 +40,27 @@ class ScheduledMessageTiming:
         self.is_chat_specific = is_chat_specific
 
 
-def create_schedule(hour: int, minute: int, message_provider: Callable[[], Awaitable[MessageWithPreview]]):
+def create_schedule(hour: int, minute: int, message_provider: Callable[[], Awaitable[MessageWithPreview]]) \
+        -> ScheduledMessageTiming:
     """
     Creates schedule for message that has same content in each chat and is not chat specific in any way.
     :param hour: staring hour in Finnish local time
     :param minute: staring minute in Finnish local time
     :param message_provider: async method which invocation produces the MessageWithPreview
-    :return:
+    :return: Scheduled message timing
     """
     return ScheduledMessageTiming(datetime.time(hour, minute), message_provider)
 
 
 def create_schedule_with_chat_context(
-        hour: int, minute: int, message_provider: Callable[[MessageBoard, int], Awaitable[MessageBoardMessage | None]]):
+        hour: int, minute: int, message_provider: Callable[[MessageBoard, int], Awaitable[MessageBoardMessage | None]]) \
+        -> ScheduledMessageTiming:
     """
     Creates schedule for message that is chat specific and which content is created for each chat separately.
     :param hour: staring hour in Finnish local time
     :param minute: staring minute in Finnish local time
     :param message_provider: async method which invocation produces the MessageBoardMessage
-    :param enabled_for_chat_predicate: optional predicate for testing if schedule should be used
-    :return:
+    :return: Scheduled message timing
     """
     return ScheduledMessageTiming(datetime.time(hour, minute), message_provider, is_chat_specific=True)
 

--- a/bobweb/bob/test_command_users.py
+++ b/bobweb/bob/test_command_users.py
@@ -7,6 +7,7 @@ from django.core import management
 from django.test import TestCase
 from unittest import mock
 
+from bobweb.bob import command_users
 from bobweb.bob.utils_format import transpose, MessageArrayFormatter
 from bobweb.bob.command_users import create_member_array, UsersCommand
 from bobweb.bob.tests_utils import assert_reply_to_contain, \
@@ -62,8 +63,30 @@ class CommandUsersTest(django.test.TransactionTestCase):
         headings = ['Nimi', 'A', 'K', 'V']
         members_array.insert(0, headings)
         actual = formatter.format(members_array)
-        expected = 'Nimi     ⌇  A⌇  K⌇     V\n~~~~~~~~~~~~~~~~~~~~~~~~\nnimismies⌇ 23⌇  0⌇  1234\nukko     ⌇  1⌇ 12⌇ 55555\n'
-        self.assertEqual(expected, actual, f'expected:\n{expected}\nactual:\n{actual}')
+        expected = ('Nimi            ⌇  A⌇  K⌇     V\n'
+                    '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n'
+                    'userWithLongName⌇ 23⌇  0⌇  1234\n'
+                    'user2           ⌇  1⌇ 12⌇ 55555\n')
+        self.assertEqual(expected, actual)
+
+    async def test_create_message_board_daily_message(self):
+        members = [create_mock_chat_member('userWithLongName', 23, 0, 1234),
+                   create_mock_chat_member('user2', 1, 12, 55555)]
+
+        with mock.patch('bobweb.bob.database.get_chat_members_for_chat', return_value=members) as mock_get_members:
+            message_board_message = await command_users.create_message_board_daily_message(None, -1)
+
+            expected = ('Käyttäjät 🤓\n'
+                        '\n'
+                        '```\n'
+                        'Nimi         ⌇  A⌇  K⌇     V\n'
+                        '============================\n'
+                        'userWithLon..⌇ 23⌇  0⌇  1234\n'
+                        'user2        ⌇  1⌇ 12⌇ 55555\n'
+                        '```\n'
+                        'A=Arvo, K=Kunnia, V=Viestit')
+            self.assertEqual(expected, message_board_message.body)
+            self.assertEqual(None, message_board_message.preview)
 
     async def test_format_member_array_truncation(self):
         maximum_row_width = 28

--- a/bobweb/bob/test_command_users.py
+++ b/bobweb/bob/test_command_users.py
@@ -58,8 +58,8 @@ class CommandUsersTest(django.test.TransactionTestCase):
 
     async def test_format_member_array(self):
         formatter = MessageArrayFormatter('⌇ ', '~',)
-        members = [create_mock_chat_member('nimismies', 23, 0, 1234),
-                   create_mock_chat_member('ukko', 1, 12, 55555)]
+        members = [create_mock_chat_member('userWithLongName', 23, 0, 1234),
+                   create_mock_chat_member('user2', 1, 12, 55555)]
         members_array = create_member_array(members)
         headings = ['Nimi', 'A', 'K', 'V']
         members_array.insert(0, headings)

--- a/bobweb/bob/test_message_board_command_and_service.py
+++ b/bobweb/bob/test_message_board_command_and_service.py
@@ -257,7 +257,7 @@ class MessageBoardServiceTests(django.test.TransactionTestCase):
             current_scheduling, next_starts_at = find_current_and_next_schedule(schedules_by_weed_day)
             # Now as the time is at midnight, current schedule should be from the previous day that started
             # at 15:00. Next schedule starts today at 9:00
-            self.assertEqual(21, current_scheduling.starting_from.hour)
+            self.assertEqual(21, current_scheduling.local_starting_from.hour)
 
             expected_next_update_at = datetime.datetime(2025, 1, 1, 9, 0, tzinfo=bob_constants.fitz)
             self.assertEqual(expected_next_update_at, next_starts_at)
@@ -265,7 +265,7 @@ class MessageBoardServiceTests(django.test.TransactionTestCase):
             # If we progress time to 10:00, now current schedule started at 9:00 and next starts at 21:00
             clock.tick(datetime.timedelta(hours=10))
             current_scheduling, next_starts_at = find_current_and_next_schedule(schedules_by_weed_day)
-            self.assertEqual(9, current_scheduling.starting_from.hour)
+            self.assertEqual(9, current_scheduling.local_starting_from.hour)
 
             expected_next_update_at = datetime.datetime(2025, 1, 1, 21, 0, tzinfo=bob_constants.fitz)
             self.assertEqual(expected_next_update_at, next_starts_at)
@@ -274,7 +274,7 @@ class MessageBoardServiceTests(django.test.TransactionTestCase):
             # next date
             clock.tick(datetime.timedelta(hours=12))
             current_scheduling, next_starts_at = find_current_and_next_schedule(schedules_by_weed_day)
-            self.assertEqual(21, current_scheduling.starting_from.hour)
+            self.assertEqual(21, current_scheduling.local_starting_from.hour)
             expected_next_update_at = datetime.datetime(2025, 1, 2, 9, 0, tzinfo=bob_constants.fitz)
             self.assertEqual(expected_next_update_at, next_starts_at)
 

--- a/bobweb/bob/test_message_board_command_and_service.py
+++ b/bobweb/bob/test_message_board_command_and_service.py
@@ -239,6 +239,7 @@ class MessageBoardServiceTests(django.test.TransactionTestCase):
         message_board = message_board_service.find_board(chat.id)
         await chat.bot.delete_message(chat.id, message_board.host_message_id)
 
+        message_board.current_message.text = 'updated'
         await message_board.update_scheduled_message_content()
         # Now board is deleted from the service and the message board message id is set null in database
         self.assertIsNone(message_board_service.find_board(chat.id))

--- a/bobweb/bob/utils_common.py
+++ b/bobweb/bob/utils_common.py
@@ -602,3 +602,16 @@ def excel_time(dt: datetime) -> float:
 def excel_date(dt: datetime | date) -> str:
     localized_dt = fitz_from(dt)
     return datetime_to_excel_datetime(localized_dt, False, True)
+
+
+def parse_dt_str_to_utctzstr(text: str) -> str | None:
+    """ Parses date and returns it. If parameter is not valid date in any predefined format, None is returned """
+    for date_format in ('%Y-%m-%d', '%d.%m.%Y', '%m/%d/%Y'):  # 2022-01-31, 31.01.2022, 01/31/2022
+        try:
+            # As only date is relevant, this is handled as Utc datetime with time of 00:00:00
+            naive_dt = datetime.strptime(text, date_format)
+            utc_transformed_dt = utctz_from(naive_dt)
+            return str(utc_transformed_dt)
+        except ValueError:
+            pass
+    return None


### PR DESCRIPTION
* Add message board schedule for Friday to show user listing with 1337 scores and daily question scores. This does not have any fancy output, but just same table format as in the corresponding command response. Better format with preview can be added later on
* Change message board shceduling to be in local Finnish time
* Fix calculating next message board scheduled update correctly with date and time
* Add support for chat-specific message board message providers to return None so that no message is updated to the board. This was added for 1337 user list score and daily question score schedules so that they will be only shown on chats which have had related activity
* Add check that Message Board does not call Telegram API, if it is tried to be updated with same content than the board contains already