### PR TITLE
Fix commit details variable references in build docker image github action

### DIFF
--- a/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
@@ -30,6 +30,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get latest commit details
+        id: commit_info
+        run: |
+          echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B)" >> $GITHUB_ENV
+          echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
+          echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -66,9 +73,9 @@ jobs:
           cache-to: type=gha,mode=max
           # Add build arguments for the commit hash and message
           build-args: |
-            COMMIT_MESSAGE=$(git log -1 --pretty=%B)
-            COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)
-            COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)
+            COMMIT_MESSAGE=${{ env.COMMIT_MESSAGE }}
+            COMMIT_AUTHOR_NAME=${{ env.COMMIT_AUTHOR_NAME }}
+            COMMIT_AUTHOR_EMAIL=${{ env.COMMIT_AUTHOR_EMAIL }}
 
       - name: Export digest
         run: |

--- a/docker-compose.prod.dockerhub.yml
+++ b/docker-compose.prod.dockerhub.yml
@@ -16,9 +16,8 @@ services:
       - "/dev/gpiomem:/dev/gpiomem"  # For GPIO pin access
     restart: always
     environment:
-      COMMIT_MESSAGE: ${COMMIT_MESSAGE}
-      COMMIT_AUTHOR_NAME: ${COMMIT_AUTHOR_NAME}
-      COMMIT_AUTHOR_EMAIL: ${COMMIT_AUTHOR_EMAIL}
+      # Note difference to other docker-compose definitions: running environment local commit
+      # details are not imported into the container as they are embedded in the image
       BOT_TOKEN: ${BOT_TOKEN}
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
       OPEN_WEATHER_API_KEY: ${OPEN_WEATHER_API_KEY}


### PR DESCRIPTION
* This should embed latest commit details (author name, email and commit message) correctly to the image
* Remove importing running environment commit detail env variables to the container when deploying from dockerhub