### PR TITLE
Add whole content of the commit message to the env variable inside the image

### DIFF
--- a/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
@@ -33,8 +33,12 @@ jobs:
       - name: Get latest commit details
         id: commit_info
         run: |
-          # Save the full commit message to a temporary file and add other details to env vars
-          git log -1 --pretty=%B > commit_message.txt
+          # Replace Newlines with an Escape Sequence and write commit message to the env variable
+          {
+            echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B | sed ':a;N;$!ba;s/\n/\\n/g')"
+          } >> $GITHUB_ENV
+  
+          # Escape author name and email
           echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
           echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
 
@@ -74,7 +78,7 @@ jobs:
           cache-to: type=gha,mode=max
           # Add build arguments for the commit hash and message
           build-args: |
-            COMMIT_MESSAGE=$(cat commit_message.txt)
+            COMMIT_MESSAGE=${{ env.COMMIT_MESSAGE }}
             COMMIT_AUTHOR_NAME=${{ env.COMMIT_AUTHOR_NAME }}
             COMMIT_AUTHOR_EMAIL=${{ env.COMMIT_AUTHOR_EMAIL }}
 

--- a/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
@@ -9,7 +9,7 @@ name: Build multi-arch image and push to Docker Hub
 
 on:
   push:
-    branches: [ main ]
+    branches: [ '*' ]
 
 env:
   REGISTRY_IMAGE: latemus/bobweb2

--- a/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
@@ -9,7 +9,7 @@ name: Build multi-arch image and push to Docker Hub
 
 on:
   push:
-    branches: [ '*' ]
+    branches: [ main ]
 
 env:
   REGISTRY_IMAGE: latemus/bobweb2

--- a/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
+++ b/.github/workflows/main_branch_build_and_push_to_dockerhub.yml
@@ -33,14 +33,8 @@ jobs:
       - name: Get latest commit details
         id: commit_info
         run: |
-          # Write commit message to env wrapped in EOF which escapes special characters like newline
-          {
-            echo "COMMIT_MESSAGE<<EOF"
-            git log -1 --pretty=%B
-            echo "EOF"
-          } >> $GITHUB_ENV
-      
-          # Escape author name and email
+          # Save the full commit message to a temporary file and add other details to env vars
+          git log -1 --pretty=%B > commit_message.txt
           echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
           echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
 
@@ -80,7 +74,7 @@ jobs:
           cache-to: type=gha,mode=max
           # Add build arguments for the commit hash and message
           build-args: |
-            COMMIT_MESSAGE=${{ env.COMMIT_MESSAGE }}
+            COMMIT_MESSAGE=$(cat commit_message.txt)
             COMMIT_AUTHOR_NAME=${{ env.COMMIT_AUTHOR_NAME }}
             COMMIT_AUTHOR_EMAIL=${{ env.COMMIT_AUTHOR_EMAIL }}
 

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -13,17 +13,16 @@ jobs:
     
     - uses: actions/checkout@v2
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 1
 
     - name: Get latest commit details
       id: commit_info
       run: |
-        # Write commit message to env wrapped in EOF which escapes special characters like newline
+        # Replace Newlines with an Escape Sequence and write commit message to the env variable
         {
-            echo "COMMIT_MESSAGE<<EOF"
-            git log -1 --pretty=%B
-            echo "EOF"
-          } >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B | sed ':a;N;$!ba;s/\n/\\n/g')"
+        } >> $GITHUB_ENV
 
         # Escape author name and email
         echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
@@ -50,7 +49,7 @@ jobs:
         # after startup it is checked that it is still running without crashing
         BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-        COMMIT_MESSAGE: $(cat commit_message.txt)
+        COMMIT_MESSAGE: ${{ env.COMMIT_MESSAGE }}
         COMMIT_AUTHOR_NAME: ${{ env.COMMIT_AUTHOR_NAME }}
         COMMIT_AUTHOR_EMAIL: ${{ env.COMMIT_AUTHOR_EMAIL }}
       run: |
@@ -76,10 +75,10 @@ jobs:
         
         # Check commit message content variables inside the container
         expected_value=$(git log -1 --pretty=%B)
-        container_value=$(docker exec $CONTAINER_NAME printenv $COMMIT_MESSAGE || echo "NOT_SET")
+        container_value=$(docker exec $CONTAINER_NAME printenv COMMIT_MESSAGE || echo "NOT_SET")
         
         if [ "$container_value" != "$expected_value" ]; then
-          echo "Environment variable '$COMMIT_MESSAGE' mismatch: Expected '$expected_value', Got '$container_value'."
+          echo "Environment variable 'COMMIT_MESSAGE' mismatch: Expected '$expected_value', Got '$container_value'."
           exit 1
         fi
         

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -18,15 +18,20 @@ jobs:
     - name: Get latest commit details
       id: commit_info
       run: |
-        # Save the full commit message to a temporary file and add other details to env vars
-        git log -1 --pretty=%B > commit_message.txt
+        # Write commit message to env wrapped in EOF which escapes special characters like newline
+        {
+            echo "COMMIT_MESSAGE<<EOF"
+            git log -1 --pretty=%B
+            echo "EOF"
+          } >> $GITHUB_ENV
+
+        # Escape author name and email
         echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
         echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
 
     - name: Debug output
       run: |
-        echo "Commit message:"
-        cat commit_message.txt
+        echo "Commit message: $COMMIT_MESSAGE"
         echo "Author name: $COMMIT_AUTHOR_NAME"
         echo "Author email: $COMMIT_AUTHOR_EMAIL"
 
@@ -71,10 +76,10 @@ jobs:
         
         # Check commit message content variables inside the container
         expected_value=$(git log -1 --pretty=%B)
-        container_value=$(docker exec $CONTAINER_NAME printenv $var || echo "NOT_SET")
+        container_value=$(docker exec $CONTAINER_NAME printenv $COMMIT_MESSAGE || echo "NOT_SET")
         
         if [ "$container_value" != "$expected_value" ]; then
-          echo "Environment variable '$var' mismatch: Expected '$expected_value', Got '$container_value'."
+          echo "Environment variable '$COMMIT_MESSAGE' mismatch: Expected '$expected_value', Got '$container_value'."
           exit 1
         fi
         

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -50,12 +50,12 @@ jobs:
         COMMIT_AUTHOR_EMAIL: ${{ env.COMMIT_AUTHOR_EMAIL }}
       run: |
         ./deploy.dev.sh
-        sleep 30
+        sleep 15
         docker ps
         
         # Check if the container is running
         if ! docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
-          echo "The container '$CONTAINER_NAME' is not running.\nLogs from the container:"
+          echo "The container '$CONTAINER_NAME' is not running."
           exit 1
         fi
         
@@ -67,8 +67,8 @@ jobs:
         fi
         
         # Check commit message content variables inside the container
-        expected_value=$(git log -1 --pretty=%B)
-        container_value=$(docker logs $CONTAINER_NAME 2>&1 | grep -oP '(?<=Commit message:\n)(.|\n)*(?=\n""")')
+        expected_value=$(git log -1 --pretty=%B | tr '\n' ' ')
+        container_value=$(docker logs $CONTAINER_NAME 2>&1 | grep -o 'Commit message:.*' | sed 's/Commit message://' | tr '\n' ' ')
         
         if [ "$container_value" != "$expected_value" ]; then
           echo "Commit message mismatch: Expected '$expected_value', Got '$container_value'."
@@ -79,10 +79,7 @@ jobs:
 
     - name: Print container logs on failure
       if: failure()
-      run: |
-        echo "### Container Logs ###"
-        echo ""
-        docker logs bobweb2-bob-1
+      run: docker logs $CONTAINER_NAME
 
   tests_and_sonar:
     name: tests_and_sonar

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -28,12 +28,6 @@ jobs:
         echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
         echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
 
-    - name: Debug output
-      run: |
-        echo "Commit message: $COMMIT_MESSAGE"
-        echo "Author name: $COMMIT_AUTHOR_NAME"
-        echo "Author email: $COMMIT_AUTHOR_EMAIL"
-
     - name: ShellCheck
       uses: ludeeus/action-shellcheck@1.1.0
 
@@ -75,10 +69,10 @@ jobs:
         
         # Check commit message content variables inside the container
         expected_value=$(git log -1 --pretty=%B)
-        container_value=$(docker exec $CONTAINER_NAME printenv COMMIT_MESSAGE || echo "NOT_SET")
+        container_value=$(docker logs $CONTAINER_NAME 2>&1 | grep -oP '(?<=Commit message:\n)(.|\n)*(?=\n""")')
         
         if [ "$container_value" != "$expected_value" ]; then
-          echo "Environment variable 'COMMIT_MESSAGE' mismatch: Expected '$expected_value', Got '$container_value'."
+          echo "Commit message mismatch: Expected '$expected_value', Got '$container_value'."
           exit 1
         fi
         

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -18,17 +18,18 @@ jobs:
     - name: Get latest commit details
       id: commit_info
       run: |
-        # Write commit message to env wrapped in EOF which escapes special characters like newline
-        {
-            echo "COMMIT_MESSAGE<<EOF"
-            git log -1 --pretty=%B
-            echo "EOF"
-          } >> $GITHUB_ENV
-
-        # Escape author name and email
+        # Save the full commit message to a temporary file and add other details to env vars
+        git log -1 --pretty=%B > commit_message.txt
         echo "COMMIT_AUTHOR_NAME=$(git log -1 --pretty=%an)" >> $GITHUB_ENV
         echo "COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%ae)" >> $GITHUB_ENV
-        
+
+    - name: Debug output
+      run: |
+        echo "Commit message:"
+        cat commit_message.txt
+        echo "Author name: $COMMIT_AUTHOR_NAME"
+        echo "Author email: $COMMIT_AUTHOR_EMAIL"
+
     - name: ShellCheck
       uses: ludeeus/action-shellcheck@1.1.0
 
@@ -44,7 +45,7 @@ jobs:
         # after startup it is checked that it is still running without crashing
         BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-        COMMIT_MESSAGE: ${{ env.COMMIT_MESSAGE }}
+        COMMIT_MESSAGE: $(cat commit_message.txt)
         COMMIT_AUTHOR_NAME: ${{ env.COMMIT_AUTHOR_NAME }}
         COMMIT_AUTHOR_EMAIL: ${{ env.COMMIT_AUTHOR_EMAIL }}
       run: |
@@ -68,16 +69,14 @@ jobs:
           exit 1
         fi
         
-        # Check environment variables inside the container
-        for var in "COMMIT_MESSAGE" "COMMIT_AUTHOR_NAME" "COMMIT_AUTHOR_EMAIL"; do
-          expected_value=$(eval echo "\${$var}")
-          container_value=$(docker exec $CONTAINER_NAME printenv $var || echo "NOT_SET")
-          
-          if [ "$container_value" != "$expected_value" ]; then
-            echo "Environment variable '$var' mismatch: Expected '$expected_value', Got '$container_value'."
-            exit 1
-          fi
-        done
+        # Check commit message content variables inside the container
+        expected_value=$(git log -1 --pretty=%B)
+        container_value=$(docker exec $CONTAINER_NAME printenv $var || echo "NOT_SET")
+        
+        if [ "$container_value" != "$expected_value" ]; then
+          echo "Environment variable '$var' mismatch: Expected '$expected_value', Got '$container_value'."
+          exit 1
+        fi
         
         echo "The container '$CONTAINER_NAME' is running and everything looks good! :-)"
 

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -66,15 +66,6 @@ jobs:
           exit 1
         fi
         
-        # Check commit message content variables inside the container
-        expected_value=$(git log -1 --pretty=%B | tr '\n' ' ')
-        container_value=$(docker logs $CONTAINER_NAME 2>&1 | grep -o 'Commit message:.*' | sed 's/Commit message://' | tr '\n' ' ')
-        
-        if [ "$container_value" != "$expected_value" ]; then
-          echo "Commit message mismatch: Expected '$expected_value', Got '$container_value'."
-          exit 1
-        fi
-        
         echo "The container '$CONTAINER_NAME' is running and everything looks good! :-)"
 
     - name: Print container logs on failure

--- a/.github/workflows/pull_request_quality_gate.yml
+++ b/.github/workflows/pull_request_quality_gate.yml
@@ -9,6 +9,8 @@ jobs:
   docker_lint_and_smoke_test:
     name: docker_lint_and_smoke_test
     runs-on: ubuntu-latest
+    env:
+      CONTAINER_NAME: bobweb2-bob-1
     steps:
     
     - uses: actions/checkout@v2
@@ -47,8 +49,6 @@ jobs:
         COMMIT_AUTHOR_NAME: ${{ env.COMMIT_AUTHOR_NAME }}
         COMMIT_AUTHOR_EMAIL: ${{ env.COMMIT_AUTHOR_EMAIL }}
       run: |
-        CONTAINER_NAME="bobweb2-bob-1"
-        EXPECTED_LOG_MESSAGE="telegram.ext.Application - info - Application started"
         ./deploy.dev.sh
         sleep 30
         docker ps
@@ -56,14 +56,13 @@ jobs:
         # Check if the container is running
         if ! docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" | grep -q "$CONTAINER_NAME"; then
           echo "The container '$CONTAINER_NAME' is not running.\nLogs from the container:"
-          docker logs $CONTAINER_NAME || echo "No logs found for '$CONTAINER_NAME'."
           exit 1
         fi
         
         # Check that bot application has logged that it was started
+        EXPECTED_LOG_MESSAGE="telegram.ext.Application - info - Application started"
         if ! docker logs $CONTAINER_NAME 2>&1 | grep "$EXPECTED_LOG_MESSAGE"; then
-          echo "Bot Application has not logged that it has started. Logs:"
-          docker logs $CONTAINER_NAME
+          echo "Bot Application has not logged that it has started."
           exit 1
         fi
         
@@ -78,6 +77,12 @@ jobs:
         
         echo "The container '$CONTAINER_NAME' is running and everything looks good! :-)"
 
+    - name: Print container logs on failure
+      if: failure()
+      run: |
+        echo "### Container Logs ###"
+        echo ""
+        docker logs bobweb2-bob-1
 
   tests_and_sonar:
     name: tests_and_sonar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3.10-bullseye
 
-# Embed latest commit information to the image if given as build parameters
-ARG COMMIT_MESSAGE
-ARG COMMIT_AUTHOR_NAME
-ARG COMMIT_AUTHOR_EMAIL
-ENV COMMIT_MESSAGE=${COMMIT_MESSAGE}
-ENV COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME}
-ENV COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
-
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /
@@ -29,5 +21,15 @@ RUN if [ "$(uname -m)" = armv7l ]; then \
 # take only needed modules and starting script to the final image
 COPY bobweb bobweb
 COPY entrypoint.sh .
+
+# Embed latest commit information to the image if given as build parameters.
+# These are positioned to be set just before the entrypoint command as these
+# values change each time causing cache invalidation on subsequent layers.
+ARG COMMIT_MESSAGE
+ARG COMMIT_AUTHOR_NAME
+ARG COMMIT_AUTHOR_EMAIL
+ENV COMMIT_MESSAGE=${COMMIT_MESSAGE}
+ENV COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME}
+ENV COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
 
 CMD ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,9 @@ COPY entrypoint.sh .
 ARG COMMIT_MESSAGE
 ARG COMMIT_AUTHOR_NAME
 ARG COMMIT_AUTHOR_EMAIL
-
-# Using a helper file to process commit message
-SHELL ["/bin/sh", "-o", "pipefail", "-c"]
-RUN /bin/sh -c 'echo -e "${COMMIT_MESSAGE}" | sed "s/\\\\n/\\n/g" > /tmp/commit_message.txt'
-
 # Set environment variables for runtime, converting file back to environment variable
-ENV COMMIT_MESSAGE=$(cat /tmp/commit_message.txt) \
-    COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME} \
-    COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
+ENV COMMIT_MESSAGE=${COMMIT_MESSAGE}
+ENV COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME}
+ENV COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
 
 CMD ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ARG COMMIT_AUTHOR_NAME
 ARG COMMIT_AUTHOR_EMAIL
 
 # Using a helper file to process commit message
+SHELL option -o pipefail
 RUN echo -e "${COMMIT_MESSAGE}" | sed 's/\\n/\n/g' > /tmp/commit_message.txt
 
 # Set environment variables for runtime, converting file back to environment variable

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,13 @@ COPY entrypoint.sh .
 ARG COMMIT_MESSAGE
 ARG COMMIT_AUTHOR_NAME
 ARG COMMIT_AUTHOR_EMAIL
-ENV COMMIT_MESSAGE=${COMMIT_MESSAGE}
-ENV COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME}
-ENV COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
+
+# Using a helper file to process commit message
+RUN echo -e "${COMMIT_MESSAGE}" | sed 's/\\n/\n/g' > /tmp/commit_message.txt
+
+# Set environment variables for runtime, converting file back to environment variable
+ENV COMMIT_MESSAGE=$(cat /tmp/commit_message.txt) \
+    COMMIT_AUTHOR_NAME=${COMMIT_AUTHOR_NAME} \
+    COMMIT_AUTHOR_EMAIL=${COMMIT_AUTHOR_EMAIL}
 
 CMD ["/bin/bash", "-c", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ ARG COMMIT_AUTHOR_NAME
 ARG COMMIT_AUTHOR_EMAIL
 
 # Using a helper file to process commit message
-SHELL option -o pipefail
-RUN echo -e "${COMMIT_MESSAGE}" | sed 's/\\n/\n/g' > /tmp/commit_message.txt
+SHELL ["/bin/sh", "-o", "pipefail", "-c"]
+RUN /bin/sh -c 'echo -e "${COMMIT_MESSAGE}" | sed "s/\\\\n/\\n/g" > /tmp/commit_message.txt'
 
 # Set environment variables for runtime, converting file back to environment variable
 ENV COMMIT_MESSAGE=$(cat /tmp/commit_message.txt) \

--- a/bobweb/bob/git_promotions.py
+++ b/bobweb/bob/git_promotions.py
@@ -18,6 +18,7 @@ async def broadcast_and_promote(context: ContextTypes.DEFAULT_TYPE) -> None:
     bob_db_object = database.get_the_bob()
     broadcast_message = os.getenv("COMMIT_MESSAGE")
     if broadcast_message != bob_db_object.latest_startup_broadcast_message and broadcast_message != "":
+        logger.info(f'Started with new commit message. Broadcasting: \n""" Commit message:\n{broadcast_message}\n"""')
         bob_db_object.latest_startup_broadcast_message = broadcast_message
         bob_db_object.save()
         try:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,8 @@ PYTHONPATH=$(pwd)
 export PYTHONPATH
 
 # Replace \n with actual newlines and export as an environment variable
-export COMMIT_MESSAGE=$(echo -e "${COMMIT_MESSAGE}")
+COMMIT_MESSAGE=$(echo -e "${COMMIT_MESSAGE}")
+export COMMIT_MESSAGE
 
 python bobweb/web/manage.py migrate --no-input
 python bobweb/web/manage.py collectstatic --noinput  # Builds static files for web build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 PYTHONPATH=$(pwd)
 export PYTHONPATH
 
+# Replace \n with actual newlines and export as an environment variable
+export COMMIT_MESSAGE=$(echo -e "${COMMIT_MESSAGE}")
+
 python bobweb/web/manage.py migrate --no-input
 python bobweb/web/manage.py collectstatic --noinput  # Builds static files for web build
 python bobweb/bob/main.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 PYTHONPATH=$(pwd)
 export PYTHONPATH
 
-# Replace \n with actual newlines and export as an environment variable
+# Replace sed escaped linebreaks '\n' with actual non-escaped newlines and export as an environment variable
 COMMIT_MESSAGE=$(echo -e "${COMMIT_MESSAGE}")
 export COMMIT_MESSAGE
 


### PR DESCRIPTION
Add whole content of the commit message to the env variable inside the image

* Now line breaks in commit message are escaped before it is added to the image environment variables and as such additional lines are no longer cut from the commit message
* Moved commit detail env var definitions to the end of Dockerfile so change in commit message won't invalidate subsequent layers