### PR TITLE
Fix gpt o1 and o1-mini models

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /
 
 RUN apt-get update -qqy \
     && apt-get -y install --no-install-recommends \
-      ffmpeg=7:4.3.8-0+deb11u1 \
-      libavcodec-extra=7:4.3.8-0+deb11u1 \
+      ffmpeg=7:4.3.8-0+deb11u2 \
+      libavcodec-extra=7:4.3.8-0+deb11u2 \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 COPY requirements.txt requirements.txt


### PR DESCRIPTION
* Mask o1 and o1-mini system messages to be sent with 'user' role. They should support 'developer', but it did not work
* Remove image capabilities from o1 and o1-mini as they have none. Bot informs user if the message history contains images and user tries to use model without vision capabilities
* Update ffmpeg and libavcodec