### PR TITLE
GPT command to use gemini-2.5-flash sometimes

### DIFF
--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -157,7 +157,7 @@ async def generate_and_format_result_text(update: Update) -> string:
 
     # For variety to user, instead of default model, use google's model (every other time)
     # This assumes that google's model has similar capabilities as default model
-    if model.name == DEFAULT_MODEL.name and random.random() < 0.5:
+    if model.name == DEFAULT_MODEL.name and random.random() < 0.5:  # NOSONAR
         url = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
         headers = {'Authorization': 'Bearer ' + config.google_genai_api_key}
         model_name = 'gemini-2.5-flash-preview-05-20'

--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -161,11 +161,13 @@ async def generate_and_format_result_text(update: Update) -> string:
         url = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
         headers = {'Authorization': 'Bearer ' + config.google_genai_api_key}
         model_name = 'gemini-2.5-flash-preview-05-20'
+        handle_not_ok_response = google_genai_api_utils.handle_google_genai_response_not_ok
     else:
         # Full API documentation: https://platform.openai.com/docs/api-reference/chat
         url = 'https://api.openai.com/v1/chat/completions'
         headers = {'Authorization': 'Bearer ' + config.openai_api_key}
         model_name = model.name
+        handle_not_ok_response = openai_api_utils.handle_openai_response_not_ok
 
     payload = {
         "model": model_name,
@@ -182,7 +184,7 @@ async def generate_and_format_result_text(update: Update) -> string:
         elif attempt < max_retries - 1:
             continue
         elif response.status != 200:
-            await openai_api_utils.handle_openai_response_not_ok(
+            await handle_not_ok_response(
                 response=response,
                 general_error_response="Vastauksen generointi epäonnistui.")
         else:

--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -188,7 +188,7 @@ async def generate_and_format_result_text(update: Update) -> string:
                 response=response,
                 general_error_response="Vastauksen generointi epäonnistui.")
         else:
-            await google_genai_api_utils.handle_google_gemini_response_ok_but_missing_content()
+            await google_genai_api_utils.handle_google_genai_response_ok_but_missing_content()
     return content
 
 

--- a/bobweb/bob/command_gpt.py
+++ b/bobweb/bob/command_gpt.py
@@ -3,6 +3,7 @@ import io
 import logging
 import re
 import string
+import random
 from typing import List, Optional
 
 import django
@@ -12,7 +13,7 @@ from telegram.ext import CallbackContext
 from telethon.tl.types import Message as TelethonMessage, Chat as TelethonChat, User as TelethonUser
 
 import bobweb
-from bobweb.bob import database, openai_api_utils, telethon_service, async_http, config
+from bobweb.bob import database, openai_api_utils, google_genai_api_utils, telethon_service, async_http, config
 from bobweb.bob.command import ChatCommand, regex_simple_command_with_parameters, get_content_after_regex_match
 from bobweb.bob.openai_api_utils import notify_message_author_has_no_permission_to_use_api, \
     ResponseGenerationException, GptModel, \
@@ -142,6 +143,7 @@ async def gpt_command(update: Update, context: CallbackContext) -> None:
 async def generate_and_format_result_text(update: Update) -> string:
     """ Determines system message, current message history and call api to generate response """
     openai_api_utils.ensure_openai_api_key_set()
+    google_genai_api_utils.ensure_google_genai_api_key_set()
 
     model: GptModel = determine_used_model(update.effective_message.text)
     message_history: List[GptChatMessage] = await form_message_history(update)
@@ -153,13 +155,22 @@ async def generate_and_format_result_text(update: Update) -> string:
 
     await send_bot_is_typing_status_update(update.effective_chat)
 
+    # For variety to user, instead of default model, use google's model (every other time)
+    # This assumes that google's model has similar capabilities as default model
+    if model.name == DEFAULT_MODEL.name and random.random() < 0.5:
+        url = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
+        headers = {'Authorization': 'Bearer ' + config.google_genai_api_key}
+        model_name = 'gemini-2.5-flash-preview-05-20'
+    else:
+        # Full API documentation: https://platform.openai.com/docs/api-reference/chat
+        url = 'https://api.openai.com/v1/chat/completions'
+        headers = {'Authorization': 'Bearer ' + config.openai_api_key}
+        model_name = model.name
+
     payload = {
-        "model": model.name,
+        "model": model_name,
         "messages": model.serialize_message_history(message_history)
     }
-    # Full API documentation: https://platform.openai.com/docs/api-reference/chat
-    url = 'https://api.openai.com/v1/chat/completions'
-    headers = {'Authorization': 'Bearer ' + config.openai_api_key}
 
     response = await async_http.post(url=url, headers=headers, json=payload)
     if response.status != 200:

--- a/bobweb/bob/config.py
+++ b/bobweb/bob/config.py
@@ -20,6 +20,9 @@ bot_token = os.getenv("BOT_TOKEN")
 # OpenAi Api key. Required for OpenAiApi related functionalities (Gpt, Dalle2, Transcribe)
 openai_api_key = os.getenv('OPENAI_API_KEY')
 
+# Google GenAI Api key. Required for Gpt
+google_genai_api_key = os.getenv('GOOGLE_GENAI_API_KEY')
+
 # Required for WeatherCommand
 open_weather_api_key = os.getenv('OPEN_WEATHER_API_KEY')
 

--- a/bobweb/bob/google_genai_api_utils.py
+++ b/bobweb/bob/google_genai_api_utils.py
@@ -9,6 +9,15 @@ from bobweb.bob.openai_api_utils import ResponseGenerationException
 logger = logging.getLogger(__name__)
 
 
+async def handle_google_gemini_response_ok_but_missing_content():
+    """ Google GenAI has a case where they return 200 but without content. """
+    error_response_to_user = "Googlen palvelu ei toimittanut."
+    log_level = logging.INFO
+    log_message = "Google GenAI API returned 200 but without content."
+    logger.log(level=log_level, msg=log_message)
+    raise ResponseGenerationException(error_response_to_user)
+
+
 def ensure_google_genai_api_key_set():
     """ Checks that google genai api key is set. Raises ValueError if not set to environmental variable. """
     if config.google_genai_api_key is None or config.google_genai_api_key == '':

--- a/bobweb/bob/google_genai_api_utils.py
+++ b/bobweb/bob/google_genai_api_utils.py
@@ -2,6 +2,7 @@ import os
 import logging
 
 from google import genai
+from aiohttp import ClientResponse
 
 from bobweb.bob import config
 from bobweb.bob.openai_api_utils import ResponseGenerationException
@@ -14,6 +15,59 @@ async def handle_google_gemini_response_ok_but_missing_content():
     error_response_to_user = "Googlen palvelu ei toimittanut."
     log_level = logging.INFO
     log_message = "Google GenAI API returned 200 but without content."
+    logger.log(level=log_level, msg=log_message)
+    raise ResponseGenerationException(error_response_to_user)
+
+
+async def handle_google_genai_response_not_ok(response: ClientResponse,
+                                        general_error_response: str):
+    """ Common error handler for all Google GenAI API non 200 ok responses.
+        API documentation: https://ai.google.dev/gemini-api/docs/troubleshooting#error-codes """
+    response_json = await response.json()
+    error = response_json[0]['error']
+    error_code = error['code']
+    error_status = error['status']
+    message = error['message']
+
+    # Default values if more exact reason cannot be extracted from response
+    error_response_to_user = general_error_response
+    log_message = f'Google GenAI API request failed. [error_code]: "{error_code}", [message]:"{message}"'
+    log_level = logging.ERROR
+
+    if response.status == 400 and error_status == 'INVALID_ARGUMENT':
+        error_response_to_user = 'Virhe keskustelun syöttämisessä Googlelle.'
+        log_message = f"Google GenAI API request body is malformed. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.ERROR
+    elif response.status == 400 and error_status == 'FAILED_PRECONDITION':
+        error_response_to_user = 'Virhe maksutiedoissa.'
+        log_message = f"Google GenAI API has problem with billing. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.ERROR
+    elif response.status == 403 and error_status == 'PERMISSION_DENIED':
+        error_response_to_user = 'Virhe autentikoitumisessa Googlen järjestelmään.'
+        log_message = f"Google GenAI API authentication failed. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.ERROR
+    elif response.status == 404 and error_status == 'NOT_FOUND':
+        error_response_to_user = 'Kysymyksistä tippui media matkalla.'
+        log_message = f"Google GenAI API was unable to see linked media. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.ERROR
+    elif response.status == 429 and error_status == 'RESOURCE_EXHAUSTED':
+        error_response_to_user = 'Käytettävissä oleva kiintiö on käytetty.'
+        log_message = f"Google GenAI API quota limit reached. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.INFO
+    elif response.status == 500 and error_status == 'INTERNAL':
+        error_response_to_user = ('Googlen palvelussa tapahtui sisäinen virhe.')
+        log_message = f"Google GenAI API internal error. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.INFO
+    elif response.status == 503 and error_status == 'UNAVAILABLE':
+        error_response_to_user = ('Googlen palvelu ei ole käytettävissä tai se on juuri nyt ruuhkautunut. '
+                                  'Ole hyvä ja yritä hetken päästä uudelleen.')
+        log_message = f"Google GenAI API rate limit exceeded. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.INFO
+    elif response.status == 504 and error_status == 'DEADLINE_EXCEEDED':
+        error_response_to_user = ('Googlen mielestä miettiminen kesti liikaa. Kokeile lyhyempää kysymystä.')
+        log_message = f"Google GenAI API unable to finish on time. [error_code]: {error_code} [message]:{message}"
+        log_level = logging.INFO
+
     logger.log(level=log_level, msg=log_message)
     raise ResponseGenerationException(error_response_to_user)
 

--- a/bobweb/bob/google_genai_api_utils.py
+++ b/bobweb/bob/google_genai_api_utils.py
@@ -10,7 +10,7 @@ from bobweb.bob.openai_api_utils import ResponseGenerationException
 logger = logging.getLogger(__name__)
 
 
-async def handle_google_gemini_response_ok_but_missing_content():
+async def handle_google_genai_response_ok_but_missing_content():
     """ Google GenAI has a case where they return 200 but without content. """
     error_response_to_user = "Googlen palvelu ei toimittanut."
     log_level = logging.INFO

--- a/bobweb/bob/google_genai_api_utils.py
+++ b/bobweb/bob/google_genai_api_utils.py
@@ -3,9 +3,17 @@ import logging
 
 from google import genai
 
+from bobweb.bob import config
 from bobweb.bob.openai_api_utils import ResponseGenerationException
 
 logger = logging.getLogger(__name__)
+
+
+def ensure_google_genai_api_key_set():
+    """ Checks that google genai api key is set. Raises ValueError if not set to environmental variable. """
+    if config.google_genai_api_key is None or config.google_genai_api_key == '':
+        logger.error('GOOGLE_GENAI_API_KEY is not set. No response was generated.')
+        raise ResponseGenerationException('Google Gen AI API key is missing from environment variables')
 
 
 class GoogleGenaiApiSession:
@@ -16,12 +24,9 @@ class GoogleGenaiApiSession:
         """
         Initializes a client if api key is set as environment variable.
         """
-        api_key = os.getenv('GOOGLE_GENAI_API_KEY')
-        if api_key is None or api_key == '':
-            logger.error('GOOGLE_GENAI_API_KEY is not set. No response was generated.')
-            raise ResponseGenerationException('Google Gen AI API key is missing from environment variables')
+        ensure_google_genai_api_key_set()
         self.default_client = genai.Client(
-            api_key=api_key
+            api_key=config.google_genai_api_key
         )
 
     def get_client(self, force_refresh=False):

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -577,6 +577,17 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         self.assertIn('OpenAi:n palvelu ei ole käytettävissä tai se on juuri nyt ruuhkautunut.',
                       chat.last_bot_txt())
 
+    async def test_service_google_response_ok_but_missing_content(self):
+        chat, user = init_chat_user()
+        with (
+            mock.patch('bobweb.bob.async_http.post', google_genai_missing_content),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            await user.send_message('/gpt test')
+
+        self.assertIn('Googlen palvelu ei toimittanut.',
+                      chat.last_bot_txt())
+
     async def test_service_google_invalid_argument(self):
         chat, user = init_chat_user()
         with (

--- a/bobweb/bob/test_command_gpt.py
+++ b/bobweb/bob/test_command_gpt.py
@@ -28,6 +28,8 @@ from bobweb.bob.tests_utils import assert_command_triggers, assert_get_parameter
     get_json, mock_openai_http_response
 from bobweb.web.bobapp.models import Chat
 
+GOOGLE_API_URL = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions'
+
 os.environ.setdefault(
     'DJANGO_SETTINGS_MODULE',
     'bobweb.web.web.settings'
@@ -61,13 +63,13 @@ class Usage:
         self.total_tokens = 42
 
 
-def assert_gpt_api_called_with(mock_method: AsyncMock, model: str, messages: list[dict[str, str]]):
+def assert_gpt_api_called_with(mock_method: AsyncMock, model: str, messages: list[dict[str, str]], url: str = 'https://api.openai.com/v1/chat/completions'):
     """
     Helper method for determining on how OpenAi http API endpoint was called. Added when Gpt was switched
     from openai python library to direct http requests.
     """
     mock_method.assert_called_with(
-        url='https://api.openai.com/v1/chat/completions',
+        url=url,
         headers={'Authorization': 'Bearer DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'},
         json={'model': model, 'messages': messages}
     )
@@ -95,6 +97,7 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         django.setup()
         management.call_command('migrate')
         bobweb.bob.config.openai_api_key = 'DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'
+        bobweb.bob.config.google_genai_api_key = 'DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'
 
     async def test_command_triggers(self):
         should_trigger = ['/gpt', '!gpt', '.gpt', '/GPT', '/gpt test',
@@ -177,10 +180,31 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         # 3 commands are sent. Each has context of 1 message
         for i in range(1, 4):
             mock_method = AsyncMock()
-            with mock.patch('bobweb.bob.async_http.post', mock_method):
+            with (
+                mock.patch('bobweb.bob.async_http.post', mock_method),
+                mock.patch('random.random', return_value=0.51)
+            ):
                 prompt = f'Prompt no. {i}'
                 await user.send_message(f'.gpt {prompt}')
                 assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=single_user_message_context(prompt))
+
+    async def test_each_command_without_replied_messages_is_in_its_own_context_google(self):
+        chat, user = init_chat_user()
+        # 3 commands are sent. Each has context of 1 message
+        for i in range(1, 4):
+            mock_method = AsyncMock()
+            with (
+                mock.patch('bobweb.bob.async_http.post', mock_method),
+                mock.patch('random.random', return_value=0.49)
+            ):
+                prompt = f'Prompt no. {i}'
+                await user.send_message(f'.gpt {prompt}')
+                assert_gpt_api_called_with(
+                    mock_method,
+                    model='gemini-2.5-flash-preview-05-20',
+                    messages=single_user_message_context(prompt),
+                    url=GOOGLE_API_URL
+                )
 
     async def test_context_content(self):
         """ A little bit more complicated test. Tests that messages in reply threads are included
@@ -195,7 +219,10 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
 
         # Use mock telethon client wrapper that does not try to use real library but instead a mock
         # that searches mock-objects from initiated chats bot-objects collections
-        with mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)):
+        with (
+            mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
+            mock.patch('random.random', return_value=0.51)
+        ):
             for i in range(1, 4):
                 # Send 3 messages where each message is reply to the previous one
                 await user.send_message(f'.gpt message {i}', reply_to_message=prev_msg_reply)
@@ -220,12 +247,59 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
             ]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_call_args_messages)
 
+    async def test_context_content_google(self):
+        """ A little bit more complicated test. Tests that messages in reply threads are included
+            in the next replies message context as expected. Here we create first a chain of
+            three gpt-command that each are replies to previous commands answer from bot. Each
+            bots answer is reply to the command that triggered it. So there is a continuous
+            reply-chain from the first gpt-command to the last reply from bot"""
+        chat, user = init_chat_user()
+        await user.send_message('.gpt .system system message')
+        self.assertEqual('System-viesti asetettu annetuksi.', chat.last_bot_txt())
+        prev_msg_reply = None
+
+        # Use mock telethon client wrapper that does not try to use real library but instead a mock
+        # that searches mock-objects from initiated chats bot-objects collections
+        with (
+            mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            for i in range(1, 4):
+                # Send 3 messages where each message is reply to the previous one
+                await user.send_message(f'.gpt message {i}', reply_to_message=prev_msg_reply)
+                prev_msg_reply = chat.last_bot_msg()
+
+            # Now that we have create a chain of 6 messages (3 commands, and 3 answers), add
+            # one more reply to the chain and check, that the MockApi is called with all previous
+            # messages in the context (in addition to the system message)
+            mock_method = AsyncMock()
+            with mock.patch('bobweb.bob.async_http.post', mock_method):
+                await user.send_message('/gpt gpt prompt', reply_to_message=prev_msg_reply)
+
+            expected_call_args_messages = [
+                {'role': 'system', 'content': [{'type': 'text', 'text': 'system message'}]},
+                {'role': 'user', 'content': [{'type': 'text', 'text': 'message 1'}]},
+                {'role': 'assistant', 'content': [{'type': 'text', 'text': 'gpt answer'}]},
+                {'role': 'user', 'content': [{'type': 'text', 'text': 'message 2'}]},
+                {'role': 'assistant', 'content': [{'type': 'text', 'text': 'gpt answer'}]},
+                {'role': 'user', 'content': [{'type': 'text', 'text': 'message 3'}]},
+                {'role': 'assistant', 'content': [{'type': 'text', 'text': 'gpt answer'}]},
+                {'role': 'user', 'content': [{'type': 'text', 'text': 'gpt prompt'}]}
+            ]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args_messages,
+                url=GOOGLE_API_URL
+            )
+
     async def test_no_system_message(self):
         chat, user = init_chat_user()
         mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
         with (
             mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
-            mock.patch('bobweb.bob.async_http.post', mock_method)
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.51)
         ):
             await user.send_message('.gpt test')
             expected_call_args_messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'test'}]}]
@@ -240,6 +314,37 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
             ]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_call_args_messages)
 
+    async def test_no_system_message_google(self):
+        chat, user = init_chat_user()
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        with (
+            mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            await user.send_message('.gpt test')
+            expected_call_args_messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'test'}]}]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args_messages,
+                url=GOOGLE_API_URL
+            )
+
+            # Now, if system message is added, it is included in call after that
+            await user.send_message('.gpt .system system message')
+            await user.send_message('.gpt test2')
+            expected_call_args_messages = [
+                {'role': 'system', 'content': [{'type': 'text', 'text': 'system message'}]},
+                {'role': 'user', 'content': [{'type': 'text', 'text': 'test2'}]}
+            ]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args_messages,
+                url=GOOGLE_API_URL
+            )
+
     async def test_gpt_command_without_any_message_as_reply_to_another_message(self):
         """
         Tests that if user replies to another message with just '/gpt' command, then that
@@ -251,7 +356,8 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
         with (
             mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
-            mock.patch('bobweb.bob.async_http.post', mock_method)
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.51)
         ):
             original_message = await user.send_message('some message')
             gpt_command_message = await user.send_message('.gpt', reply_to_message=original_message)
@@ -264,6 +370,42 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
             expected_call_args_messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'some message'}]},
                                            {'role': 'user', 'content': [{'type': 'text', 'text': 'something else'}]}]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_call_args_messages)
+
+    async def test_gpt_command_without_any_message_as_reply_to_another_message_google(self):
+        """
+        Tests that if user replies to another message with just '/gpt' command, then that
+        other message (and any messages in the reply chain) are included in the api calls
+        context message history. The '/gpt' command message itself is not included, as it
+        contains nothing else than the command itself.
+        """
+        chat, user = init_chat_user()
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        with (
+            mock.patch('bobweb.bob.telethon_service.client', MockTelethonClientWrapper(chat.bot)),
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            original_message = await user.send_message('some message')
+            gpt_command_message = await user.send_message('.gpt', reply_to_message=original_message)
+            expected_call_args_messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'some message'}]}]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args_messages,
+                url=GOOGLE_API_URL
+            )
+
+            # Now, if there is just a gpt-command in the reply chain, that message is excluded from
+            # the context message history for later calls
+            await user.send_message('/gpt something else', reply_to_message=gpt_command_message)
+            expected_call_args_messages = [{'role': 'user', 'content': [{'type': 'text', 'text': 'some message'}]},
+                                           {'role': 'user', 'content': [{'type': 'text', 'text': 'something else'}]}]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args_messages,
+                url=GOOGLE_API_URL
+            )
 
     async def test_prints_system_prompt_if_sub_command_given_without_parameters(self):
         # Create a new chat. Expect bot to tell, that system msg is empty
@@ -316,7 +458,10 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
 
     async def test_quick_system_prompt(self):
         mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
-        with mock.patch('bobweb.bob.async_http.post', mock_method):
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.51)
+        ):
             chat, user = init_chat_user()
             await user.send_message('hi')  # Saves user and chat to the database
             chat_entity = Chat.objects.get(id=chat.id)
@@ -328,9 +473,34 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
                                   {'role': 'user', 'content': [{'type': 'text', 'text': 'gpt prompt'}]}]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_call_args)
 
+    async def test_quick_system_prompt_google(self):
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            chat, user = init_chat_user()
+            await user.send_message('hi')  # Saves user and chat to the database
+            chat_entity = Chat.objects.get(id=chat.id)
+            chat_entity.quick_system_prompts = {'1': 'quick system message'}
+            chat_entity.save()
+            await user.send_message('/gpt /1 gpt prompt')
+
+            expected_call_args = [{'role': 'system', 'content': [{'type': 'text', 'text': 'quick system message'}]},
+                                  {'role': 'user', 'content': [{'type': 'text', 'text': 'gpt prompt'}]}]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_call_args,
+                url=GOOGLE_API_URL
+            )
+
     async def test_another_quick_system_prompt(self):
         mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
-        with mock.patch('bobweb.bob.async_http.post', mock_method):
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.51)
+        ):
             chat, user = init_chat_user()
             await user.send_message('hi')  # Saves user and chat to the database
             chat_entity = Chat.objects.get(id=chat.id)
@@ -344,6 +514,31 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
                                      'content': [{'type': 'text', 'text': 'gpt prompt'}]}
             expected_messages = [expected_system_message, expected_user_message]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_messages)
+
+    async def test_another_quick_system_prompt_google(self):
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            chat, user = init_chat_user()
+            await user.send_message('hi')  # Saves user and chat to the database
+            chat_entity = Chat.objects.get(id=chat.id)
+            chat_entity.quick_system_prompts = {'2': 'quick system message'}
+            chat_entity.save()
+            await user.send_message('/gpt /2 gpt prompt')
+
+            expected_system_message = {'role': 'system',
+                                       'content': [{'type': 'text', 'text': 'quick system message'}]}
+            expected_user_message = {'role': 'user',
+                                     'content': [{'type': 'text', 'text': 'gpt prompt'}]}
+            expected_messages = [expected_system_message, expected_user_message]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_messages,
+                url=GOOGLE_API_URL
+            )
 
     async def test_empty_prompt_after_quick_system_prompt(self):
         chat, user = init_chat_user()
@@ -435,13 +630,40 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         chat, user = init_chat_user()
 
         mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
-        with mock.patch('bobweb.bob.async_http.post', mock_method):
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.51)
+        ):
             expected_message_with_vision = [{'role': 'user', 'content': [{'type': 'text', 'text': 'test'}]}]
 
             await user.send_message('/gpt test')
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_message_with_vision)
             await user.send_message('/gpto1 test')
             assert_gpt_api_called_with(mock_method, model='o1-preview', messages=expected_message_with_vision)
+
+    async def test_given_model_version_is_in_openai_api_call_and_excluded_from_prompt_google(self):
+        chat, user = init_chat_user()
+
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            expected_message_with_vision = [{'role': 'user', 'content': [{'type': 'text', 'text': 'test'}]}]
+
+            await user.send_message('/gpt test')
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_message_with_vision,
+                url=GOOGLE_API_URL
+            )
+            await user.send_message('/gpto1 test')
+            assert_gpt_api_called_with(
+                mock_method,
+                model='o1-preview',
+                messages=expected_message_with_vision
+            )
 
     async def test_message_with_image(self):
         """
@@ -454,8 +676,11 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
         mock_image_bytes = b'\0'
         mock_telethon_client = MockTelethonClientWrapper(chat.bot)
         mock_telethon_client.image_bytes_to_return = [io.BytesIO(mock_image_bytes)]
-        with (mock.patch('bobweb.bob.async_http.post', mock_method),
-              mock.patch('bobweb.bob.telethon_service.client', mock_telethon_client)):
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('bobweb.bob.telethon_service.client', mock_telethon_client),
+            mock.patch('random.random', return_value=0.51)
+        ):
             photo = (PhotoSize('1', '1', 1, 1, 1),)  # Tuple of PhotoSize objects
             initial_message = await user.send_message('/gpt foo', photo=photo)
 
@@ -481,6 +706,58 @@ class ChatGptCommandTests(django.test.TransactionTestCase):
                      {'type': 'text', 'text': 'bar'}]}
             ]
             assert_gpt_api_called_with(mock_method, model='gpt-4o', messages=expected_messages)
+
+    async def test_message_with_image_google(self):
+        """
+        Case where user sends a gpt command message with an image and then replies to it with another message.
+        Bot should contain same base64 string for the image in both of the requests
+        """
+        chat, user = init_chat_user()
+
+        mock_method = mock_openai_http_response(status=200, response_json_body=get_json(MockOpenAIObject()))
+        mock_image_bytes = b'\0'
+        mock_telethon_client = MockTelethonClientWrapper(chat.bot)
+        mock_telethon_client.image_bytes_to_return = [io.BytesIO(mock_image_bytes)]
+        with (
+            mock.patch('bobweb.bob.async_http.post', mock_method),
+            mock.patch('bobweb.bob.telethon_service.client', mock_telethon_client),
+            mock.patch('random.random', return_value=0.49)
+        ):
+            photo = (PhotoSize('1', '1', 1, 1, 1),)  # Tuple of PhotoSize objects
+            initial_message = await user.send_message('/gpt foo', photo=photo)
+
+            # Now message history list should have the image url in it
+            base64_encoded_bytes = base64.b64encode(b'\0').decode('utf-8')
+            expected_initial_message = {'role': 'user',
+                                        'content': [
+                                            {'type': 'text', 'text': 'foo'},
+                                            {'type': 'image_url',
+                                             'image_url': {'url': 'data:image/jpeg;base64,' + base64_encoded_bytes}}
+                                        ]}
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=[expected_initial_message],
+                url=GOOGLE_API_URL
+            )
+
+            # Bots response is now ignored and the user replies to their previous message.
+            # Should have same content as previously with the image in the message.
+            # Users new message has been added to the history
+
+            await user.send_message('/gpt bar', reply_to_message=initial_message)
+            expected_messages = [
+                expected_initial_message,  # Same message as previously
+                {'role': 'user',
+                 'content': [
+                     {'type': 'text', 'text': 'bar'}]}
+            ]
+            assert_gpt_api_called_with(
+                mock_method,
+                model='gemini-2.5-flash-preview-05-20',
+                messages=expected_messages,
+                url=GOOGLE_API_URL
+            )
 
     async def test_request_for_model_without_vision_capabilities_and_context_containing_images(self):
         chat, user = init_chat_user()

--- a/bobweb/bob/test_command_speech.py
+++ b/bobweb/bob/test_command_speech.py
@@ -8,7 +8,7 @@ from bobweb.bob import main
 from bobweb.bob.command import ChatCommand
 from bobweb.bob.command_speech import SpeechCommand
 from bobweb.bob.tests_mocks_v2 import init_chat_user
-from bobweb.bob.tests_utils import assert_command_triggers, mock_openai_http_response, mock_google_genai_http_response
+from bobweb.bob.tests_utils import assert_command_triggers, mock_openai_http_response
 
 
 speech_api_mock_response_200 = mock_openai_http_response(response_bytes_body=str.encode('this is hello.mp3 in bytes'))
@@ -24,10 +24,6 @@ openai_service_unavailable_error = mock_openai_http_response(
 
 openai_api_rate_limit_error = mock_openai_http_response(
     status=429, response_json_body={'error': {'code': 'rate_limit', 'message': ''}})
-
-
-google_genai_invalid_content = mock_google_genai_http_response(
-    status=400, response_json_body=[{'error': {'code': '', 'status': 'INVALID_ARGUMENT', 'message': ''}}])
 
 
 @pytest.mark.asyncio

--- a/bobweb/bob/test_command_speech.py
+++ b/bobweb/bob/test_command_speech.py
@@ -8,7 +8,7 @@ from bobweb.bob import main
 from bobweb.bob.command import ChatCommand
 from bobweb.bob.command_speech import SpeechCommand
 from bobweb.bob.tests_mocks_v2 import init_chat_user
-from bobweb.bob.tests_utils import assert_command_triggers, mock_openai_http_response
+from bobweb.bob.tests_utils import assert_command_triggers, mock_openai_http_response, mock_google_genai_http_response
 
 
 speech_api_mock_response_200 = mock_openai_http_response(response_bytes_body=str.encode('this is hello.mp3 in bytes'))
@@ -24,6 +24,10 @@ openai_service_unavailable_error = mock_openai_http_response(
 
 openai_api_rate_limit_error = mock_openai_http_response(
     status=429, response_json_body={'error': {'code': 'rate_limit', 'message': ''}})
+
+
+google_genai_invalid_content = mock_google_genai_http_response(
+    status=400, response_json_body=[{'error': {'code': '', 'status': 'INVALID_ARGUMENT', 'message': ''}}])
 
 
 @pytest.mark.asyncio

--- a/bobweb/bob/test_openai_api_utils.py
+++ b/bobweb/bob/test_openai_api_utils.py
@@ -53,6 +53,7 @@ class OpenaiApiUtilsTest(django.test.TransactionTestCase):
         telegram_user = database.get_telegram_user(cc_holder_id)
         database.set_credit_card_holder(telegram_user)
         bobweb.bob.config.openai_api_key = 'DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'
+        bobweb.bob.config.google_genai_api_key = 'DUMMY_VALUE_FOR_ENVIRONMENT_VARIABLE'
 
     async def test_ensure_openai_api_key_set_raises_error_if_no_key(self):
         """

--- a/bobweb/bob/tests_utils.py
+++ b/bobweb/bob/tests_utils.py
@@ -206,3 +206,23 @@ def mock_openai_http_response(status: int = 200,
         return mock_response
 
     return AsyncMock(side_effect=mock_method_to_call_side_effect)
+
+
+def mock_google_genai_http_response(status: int = 200,
+                              response_json_body: list[dict] = None,
+                              response_bytes_body: bytes = None):
+
+    async def mock_method_to_call_side_effect(*args, **kwargs):
+        async def mock_json():
+            return response_json_body
+
+        async def mock_read():
+            return response_bytes_body
+
+        mock_response = Mock(spec=ClientResponse)
+        mock_response.status = status
+        mock_response.json = mock_json
+        mock_response.read = mock_read
+        return mock_response
+
+    return AsyncMock(side_effect=mock_method_to_call_side_effect)


### PR DESCRIPTION
We could have `/gpt` command sometimes give answers from current default model and sometimes it could give answers from this google's model we have not seen before. This "gemini-2.5-flash" seems more suitable than the current flagship "gemini-2.5-pro" due to costs.

If it's well received, we could switch the default to that as well.

They claim to follow OpenAI format if this URL is used which is nice. Don't know if error messages are the same as well.