### PR TITLE
Add back Rust toolchain for litellm dep tiktoken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ ENV PYTHONUNBUFFERED 1
 
 WORKDIR /
 
+# Install Rust toolchain for tiktoken
+# Tiktoken requires Rust toolchain, so build it in a separate stage. Pipefail: hadolint DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# Set required PATH
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # hadolint ignore=DL3008
 RUN apt-get update -qqy \
     && apt-get -y install --no-install-recommends \


### PR DESCRIPTION
This was removed here: https://github.com/M4R774/bobweb2/pull/280

but is now needed again to build Tiktoken that is needed to install Litellm.