### PR TITLE
Add provider prefix to model name

### DIFF
--- a/bot/commands/gpt.py
+++ b/bot/commands/gpt.py
@@ -20,7 +20,7 @@ from web.bobapp.models import Chat as ChatEntity
 
 SYSTEM_MESSAGE_SET = "System-viesti asetettu annetuksi."
 
-CURRENT_MODEL = "claude-opus-4-6"
+CURRENT_MODEL = "anthropic/claude-opus-4-6"
 
 logger = logging.getLogger(__name__)
 

--- a/bot/commands/test_gpt.py
+++ b/bot/commands/test_gpt.py
@@ -28,7 +28,7 @@ TELETHON_SERVICE_CLIENT = 'bot.telethon_service.client'
 
 LITELLM_ACOMPLETION = 'bot.litellm_utils.litellm.acompletion'
 
-test_model_name = 'claude-opus-4-6'
+test_model_name = 'anthropic/claude-opus-4-6'
 
 
 class MockLiteLLMResponseObject:


### PR DESCRIPTION
Error claims that LLM Provider is not provided, at least on litellm version 1.75.9. Seems like 1.75.8 worked without.

This PR adds this missing provider prefix.