### PR TITLE
Upgrade image generating model from gpt-image-1 to gpt-image-1.5

### DIFF
--- a/bot/image_generating_service.py
+++ b/bot/image_generating_service.py
@@ -29,7 +29,7 @@ async def generate_using_openai_api(prompt: str, image_size: str = '1024x1024') 
     """
     # Edit endpoint requires json body
     body = {
-        "model": "gpt-image-1",
+        "model": "gpt-image-1.5",
         "prompt": prompt,
         "n": 1,
         "background": "opaque",  # transparent is also possible now (change JPEG -> PNG)
@@ -50,7 +50,7 @@ async def edit_using_openai_api(prompt: str, message_history: List[ChatMessage],
     """
     # Edit endpoint requires form data
     form = FormData()
-    form.add_field('model', 'gpt-image-1')
+    form.add_field('model', 'gpt-image-1.5')
     form.add_field('prompt', prompt)
     form.add_field('n', '1')
     form.add_field('background', 'opaque')  # transparent is also possible now (change JPEG -> PNG)


### PR DESCRIPTION
In this PR,
- We have improved image generating model available, so let's use it (gpt-image-1.5). Although, it is from December 2025 already.